### PR TITLE
chore: update sourcepointId to name

### DIFF
--- a/src/third-party-tags/facebook-pixel.ts
+++ b/src/third-party-tags/facebook-pixel.ts
@@ -6,6 +6,6 @@ export const fbPixel: GetThirdPartyTag = ({
 }) => ({
 	shouldRun,
 	url: `https://www.facebook.com/tr?id=${facebookAccountId}&ev=PageView&noscript=1`,
-	sourcepointId: '5e7e1298b8e05c54a85c52d2',
+	name: 'fb',
 	useImage: true,
 });

--- a/src/third-party-tags/facebook-pixel.ts
+++ b/src/third-party-tags/facebook-pixel.ts
@@ -1,8 +1,6 @@
 import { GetThirdPartyTag } from '../types';
 
-export const fbPixel: GetThirdPartyTag = ({
-	shouldRun,
-}) => ({
+export const fbPixel: GetThirdPartyTag = ({ shouldRun }) => ({
 	shouldRun,
 	url: `https://www.facebook.com/tr?id=279880532344561&ev=PageView&noscript=1`,
 	name: 'fb',

--- a/src/third-party-tags/facebook-pixel.ts
+++ b/src/third-party-tags/facebook-pixel.ts
@@ -2,10 +2,9 @@ import { GetThirdPartyTag } from '../types';
 
 export const fbPixel: GetThirdPartyTag = ({
 	shouldRun,
-	facebookAccountId,
 }) => ({
 	shouldRun,
-	url: `https://www.facebook.com/tr?id=${facebookAccountId}&ev=PageView&noscript=1`,
+	url: `https://www.facebook.com/tr?id=279880532344561&ev=PageView&noscript=1`,
 	name: 'fb',
 	useImage: true,
 });

--- a/src/third-party-tags/ias.spec.ts
+++ b/src/third-party-tags/ias.spec.ts
@@ -5,7 +5,7 @@ describe('index', () => {
 		expect(ias({ shouldRun: true })).toStrictEqual({
 			shouldRun: true,
 			url: '//cdn.adsafeprotected.com/iasPET.1.js',
-			sourcepointId: '5e7ced57b8e05c485246ccf3',
+			name: 'ias',
 		});
 	});
 });

--- a/src/third-party-tags/ias.ts
+++ b/src/third-party-tags/ias.ts
@@ -3,5 +3,5 @@ import { GetThirdPartyTag } from '../types';
 export const ias: GetThirdPartyTag = ({ shouldRun }) => ({
 	shouldRun,
 	url: '//cdn.adsafeprotected.com/iasPET.1.js',
-	sourcepointId: '5e7ced57b8e05c485246ccf3',
+	name: 'ias',
 });

--- a/src/third-party-tags/permutive.spec.ts
+++ b/src/third-party-tags/permutive.spec.ts
@@ -5,7 +5,7 @@ describe('index', () => {
 		expect(permutive({ shouldRun: true })).toStrictEqual({
 			shouldRun: true,
 			url: '//cdn.permutive.com/d6691a17-6fdb-4d26-85d6-b3dd27f55f08-web.js',
-			sourcepointId: '5eff0d77969bfa03746427eb',
+			name: 'permutive',
 		});
 	});
 });

--- a/src/third-party-tags/permutive.ts
+++ b/src/third-party-tags/permutive.ts
@@ -3,5 +3,5 @@ import { GetThirdPartyTag } from '../types';
 export const permutive: GetThirdPartyTag = ({ shouldRun }) => ({
 	shouldRun,
 	url: '//cdn.permutive.com/d6691a17-6fdb-4d26-85d6-b3dd27f55f08-web.js',
-	sourcepointId: '5eff0d77969bfa03746427eb',
+	name: 'permutive',
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,6 @@ export type TagAtrribute = {
 
 export type GetThirdPartyTag = (arg0: {
 	shouldRun: boolean;
-	facebookAccountId?: string;
 }) => ThirdPartyTag;
 
 export type ThirdPartyTag = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type ThirdPartyTag = {
 	loaded?: boolean;
 	onLoad?: () => void;
 	shouldRun: boolean;
-	sourcepointId?: string;
+	name?: string;
 	url?: string;
 	useImage?: boolean;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,7 @@ export type TagAtrribute = {
 	value: string;
 };
 
-export type GetThirdPartyTag = (arg0: {
-	shouldRun: boolean;
-}) => ThirdPartyTag;
+export type GetThirdPartyTag = (arg0: { shouldRun: boolean }) => ThirdPartyTag;
 
 export type ThirdPartyTag = {
 	async?: boolean;


### PR DESCRIPTION
## What does this change?

Sourcepoint Id is moved to `consent-management-platform` and name is used instead to use inside the `getConsentFor` 
https://github.com/guardian/consent-management-platform/pull/276

## Why?
Will work with new cmp release
