### PR TITLE
build(package.json): syntax for glob to select files 

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		]
 	},
 	"lint-staged": {
-		"*.js,*.ts": "eslint --fix"
+		"*.js|*.ts": "eslint --fix"
 	},
 	"config": {
 		"commitizen": {


### PR DESCRIPTION
in lint-staged was incorrect

## What does this change?
Corrects the syntax


## Why?
The library uses https://github.com/micromatch/micromatch which needs bar for or not commas
