### PR TITLE
ci: Semantic PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,21 @@
+<!--
+
+If this PR should trigger a release, make sure your title is prefixed with one of these:
+
+- fix: (patch release)
+- feat: (minor release)
+
+These can be used but will not trigger a release:
+
+build: | chore: | ci: | docs: | style: | refactor: | perf: | test:
+
+To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:
+
+- refactor!: drop support for Node 6
+- fix!: remove old conflicting method
+
+-->
+
 ## What does this change?
 
-
-
 ## Why?
-

--- a/.github/workflows/semantic-PRs.yml
+++ b/.github/workflows/semantic-PRs.yml
@@ -1,0 +1,15 @@
+name: 'Lint PR'
+on:
+    pull_request_target:
+        types:
+            - opened
+            - edited
+            - synchronize
+
+jobs:
+    main:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: amannn/action-semantic-pull-request@v1.2.0
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -31,10 +31,8 @@
 	},
 	"husky": {
 		"hooks": {
-			"commit-msg": "commitlint -E HUSKY_GIT_PARAMS HUSKY_USE_YARN > /dev/null 2>&1 || (echo \"\n\u001b[0;31m✖ Invalid commit message\u001b[0m \u001b[2mhttps://git.io/JUzbH\u001b[0m\nTry \u001b[0;36myarn commit\u001b[0m instead\n\" && exit 1)",
 			"pre-commit": "npm-run-all precommit:*",
 			"pre-push": "npm-run-all prepush:*"
-
 		}
 	},
 	"commitlint": {
@@ -44,11 +42,6 @@
 	},
 	"lint-staged": {
 		"*.js|*.ts": "eslint --fix"
-	},
-	"config": {
-		"commitizen": {
-			"path": "cz-conventional-changelog"
-		}
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^11.0.0",


### PR DESCRIPTION
## What does this change?

- lints PRs for conventional commit compliance, rather than individual commits

## Why?

- we should get the benefit of automatic semantic release without getting too involved with individual developer's ways of working