### PR TITLE
chore: Automatically merge minor dependencies bumps

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+on:
+  pull_request:
+    branches-ignore:
+      - 'gh-pages'
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,8 +1,8 @@
-name: auto-merge
+name: Merge Dependabot PRs automatically
 on:
   pull_request:
-    branches-ignore:
-      - 'gh-pages'
+    branches:
+      - 'dependabot/*'
 jobs:
   auto-merge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this change?

When `patch` or `minor` updates are raised by @dependabot, merge them automatically if all tests pass.

As the PR titles start with `chore:`, these automatic merges should never trigger a package release.

Uses https://github.com/marketplace/actions/dependabot-auto-merge

## Why?

- Less noise for developers, requiring attention only if tests do not pass.
- No more [bundled updates](https://github.com/guardian/commercial-core/pull/130), which make semantic release notes less useful.
