### PR TITLE
feat: make trackername optional

### DIFF
--- a/src/GoogleAnalytics.ts
+++ b/src/GoogleAnalytics.ts
@@ -6,15 +6,13 @@ export const trackEvent = (
 	const { ga, guardian } = window;
 	const trackerName: string | undefined =
 		guardian.config?.googleAnalytics?.trackers.editorial;
-	if (typeof ga === 'undefined' || typeof trackerName === 'undefined') {
-		console.error(
-			"Can't track GA event - GA library not loaded or no tracker found",
-		);
+	if (typeof ga === 'undefined') {
+		console.error("Can't track GA event - GA library not loaded");
 		return;
 	}
 	const timeSincePageLoad: number = Math.round(window.performance.now());
 
-	const send = `${trackerName}.send`;
+	const send = trackerName ? `${trackerName}.send` : 'send';
 	window.ga(
 		send,
 		'timing',


### PR DESCRIPTION
## What does this change?
Tracker name will default to the one set in `ga.create` if not set 

## Why?
To keep monitoring events without tracker name specified in window.config