### PR TITLE
chore(CD): Validate single commit

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -13,3 +13,5 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v3.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true


### PR DESCRIPTION
## What does this change?

Enables `validateSingleCommit`, which was added in [`action-semantic-pull-request` 3.4.0](https://github.com/amannn/action-semantic-pull-request/releases/tag/v3.4.0)

## Why?

We’ve been bitten before!