### PR TITLE
fix: call mark if performance API exists

### DIFF
--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -106,18 +106,21 @@ export class EventTimer {
 		};
 	}
 
-	mark(name: string): PerformanceEntry {
+	mark(name: string): void {
 		const longName = `gu.commercial.${name}`;
-		window.performance.mark(longName);
-
-		// Most recent mark with this name is the event we just created.
-		const mark = window.performance
-			.getEntriesByName(longName, 'mark')
-			.slice(-1)[0];
-		if (typeof mark !== 'undefined') {
-			this.events.push(new Event(name, mark));
+		if (
+			typeof window.performance !== 'undefined' &&
+			'mark' in window.performance
+		) {
+			window.performance.mark(longName);
+			// Most recent mark with this name is the event we just created.
+			const mark = window.performance
+				.getEntriesByName(longName, 'mark')
+				.slice(-1)[0];
+			if (typeof mark !== 'undefined') {
+				this.events.push(new Event(name, mark));
+			}
 		}
-		return mark;
 	}
 
 	/**


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Performance API seems to be undefined on mobiles. 
It got picked up by Sentry here:
https://sentry.io/organizations/the-guardian/issues/2246881950/?project=35463&query=is%3Aunresolved

Also refactored mark to void as the return is not used

## Why?
Less errors in sentry
