### PR TITLE
chore: run jobs on PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches-ignore:
       - 'gh-pages'
+  pull_request:
+    branches-ignore:
+      - 'gh-pages'
 jobs:
   docs:
     name: Docs


### PR DESCRIPTION
## What does this change?

ensures that test coverage is run on PR creation too, which in turn ensures that PRs are compared against main, not themselves

## Why?

accurate coverage change reporting