### PR TITLE
feat: Send commercial metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "husky": "^6.0.0",
     "jest": "^26.6.3",
     "lint-staged": "^11.0.0",
+    "mockdate": "^3.0.5",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
     "semantic-release": "^17.4.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "@commitlint/cli": "^12.0.1",
     "@commitlint/config-conventional": "^12.0.1",
     "@guardian/eslint-config-typescript": "^0.5.0",
+    "@guardian/libs": "^2.0.0",
     "@guardian/prettier": "^0.5.0",
+    "@guardian/types": "^6.1.0",
     "@octokit/core": "^3.2.5",
     "@semantic-release/github": "7.2.3",
     "@types/doubleclick-gpt": "^2019111201.0.0",
@@ -70,5 +72,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "@guardian/libs": "^2.0.0",
+    "@guardian/types": "^6.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,5 @@ export { twitter } from './third-party-tags/twitter-uwt';
 export { inizio } from './third-party-tags/inizio';
 export { remarketing } from './third-party-tags/remarketing';
 export { EventTimer } from './EventTimer';
-
+export { sendCommercialMetrics } from './sendCommercialMetrics';
 export type { ThirdPartyTag } from './types';

--- a/src/sendCommercialMetrics.spec.ts
+++ b/src/sendCommercialMetrics.spec.ts
@@ -1,0 +1,47 @@
+import MockDate from 'mockdate';
+import { sendCommercialMetrics } from './sendCommercialMetrics';
+
+describe('sendCommercialMetrics', () => {
+	beforeAll(() => {
+		MockDate.set('Fri Jan 1 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
+	});
+
+	afterAll(() => {
+		MockDate.reset();
+	});
+
+	const sendBeacon = jest.fn().mockReturnValue(true);
+	Object.defineProperty(navigator, 'sendBeacon', {
+		configurable: true,
+		enumerable: true,
+		value: sendBeacon,
+		writable: true,
+	});
+
+	Object.defineProperty(document, 'visibilityState', { value: 'hidden' });
+
+	it('send commercial metrics success', () => {
+		expect(
+			sendCommercialMetrics('page view id', 'browser id', true),
+		).toEqual(true);
+
+		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+			[
+				'//performance-events.code.dev-guardianapis.com/commercial-metrics',
+				JSON.stringify({
+					browser_id: 'browser id',
+					page_view_id: 'page view id',
+					received_timestamp: '2021-01-01T12:00:00.000Z',
+					received_date: '2021-01-01',
+					platform: 'NEXT_GEN',
+					metrics: [],
+					properties: [
+						{ name: 'downlink', value: 'undefined' },
+						{ name: 'effectiveType', value: 'undefined' },
+						{ name: 'isDev', value: 'localhost' },
+					],
+				}),
+			],
+		]);
+	});
+});

--- a/src/sendCommercialMetrics.spec.ts
+++ b/src/sendCommercialMetrics.spec.ts
@@ -18,9 +18,11 @@ describe('sendCommercialMetrics', () => {
 		writable: true,
 	});
 
-	Object.defineProperty(document, 'visibilityState', { value: 'hidden' });
-
 	it('send commercial metrics success', () => {
+		Object.defineProperty(document, 'visibilityState', {
+			value: 'hidden',
+			writable: true,
+		});
 		expect(
 			sendCommercialMetrics('page view id', 'browser id', true),
 		).toEqual(true);
@@ -43,5 +45,17 @@ describe('sendCommercialMetrics', () => {
 				}),
 			],
 		]);
+	});
+
+	it('commercial metrics not sent when window is visible', () => {
+		Object.defineProperty(document, 'visibilityState', {
+			value: 'visible',
+			writable: true,
+		});
+		expect(
+			sendCommercialMetrics('page view id', 'browser id', true),
+		).toEqual(false);
+
+		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([]);
 	});
 });

--- a/src/sendCommercialMetrics.ts
+++ b/src/sendCommercialMetrics.ts
@@ -1,0 +1,66 @@
+import { log } from '@guardian/libs';
+import { EventTimer } from './EventTimer';
+
+type CommercialMetrics = {
+	browser_id?: string;
+	page_view_id: string;
+	received_timestamp: string;
+	received_date: string;
+	platform: string;
+	metrics: Metrics[];
+	properties: Properties[];
+};
+
+type Metrics = {
+	name: string;
+	value: number;
+};
+
+type Properties = {
+	name: string;
+	value: string;
+};
+
+export function sendCommercialMetrics(
+	pageViewId: string,
+	browserId: string | undefined,
+	isDev: boolean,
+): boolean {
+	const devProperties: Properties[] = isDev
+		? [{ name: 'isDev', value: window.location.hostname }]
+		: [];
+
+	const endpoint = isDev
+		? '//performance-events.code.dev-guardianapis.com/commercial-metrics'
+		: '//performance-events.guardianapis.com/commercial-metrics';
+	if (document.visibilityState !== 'hidden') return false;
+
+	const timestamp = new Date().toISOString();
+	const date = timestamp.slice(0, 10);
+	const eventTimer = EventTimer.get();
+	const events = eventTimer.events;
+
+	const properties: Properties[] = Object.entries(eventTimer.properties)
+		.map((property) => {
+			const [name, value] = property;
+			return { name, value: String(value) };
+		})
+		.concat(devProperties);
+
+	const metrics: Metrics[] = events.map((event) => {
+		return { name: event.name, value: Math.ceil(event.ts) };
+	});
+
+	const commercialMetrics: CommercialMetrics = {
+		browser_id: browserId,
+		page_view_id: pageViewId,
+		received_timestamp: timestamp,
+		received_date: date,
+		platform: 'NEXT_GEN',
+		metrics,
+		properties,
+	};
+
+	log('commercial', 'About to send commercial metrics', commercialMetrics);
+	return navigator.sendBeacon(endpoint, JSON.stringify(commercialMetrics));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5197,6 +5197,11 @@ mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,10 +466,20 @@
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-0.5.0.tgz#ece14ec90b372932c7bf01992fc6d8ce58f7f26e"
   integrity sha512-THJn0wg7i9YjSVM9ofobsJgS+WH9ybrZH1+0CXLAebp0T53RGtgZUkek82mDg1h3DidsM+f7HSZqoQyrCbPzPw==
 
+"@guardian/libs@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-2.0.0.tgz#8582703eb510df2e1c29b4b57aa81213dd63fd6f"
+  integrity sha512-rcl6BnePEh/ecp1Vgd8lA2ZANLjLSiHyG4F7RnlLNsr+G0U756/YJpLZRZ5HevALLLrU+g02c51yiSEqpDXFZw==
+
 "@guardian/prettier@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.5.0.tgz#d8ea25cc396f31bd4baedb8f6d7d3727a9af1fa7"
   integrity sha512-IYXMdqW6vg9mVnAXbbWCm0R9AZfWlAjfJ668TnCx3ypX5/u4AYAXdOfrWWX+uWvFvs3Ulub+E8vEm+eUkxi6rQ==
+
+"@guardian/types@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-6.1.0.tgz#5189c34c5cc4da1e549f70706c78276fa69ef7d3"
+  integrity sha512-CP1bmqOutfG/hLQrAzBaqj9EitCNPJQ1qTyHfiCAElFsWKofYuEzMgHYM2ut5nSrkSC+n0AhXUt3qItl+2A3eQ==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
## What does this change?
Moves logic around sending commercial metrics from front end

## Why?
- Keeps more commercial-specific code in commercial-core
- Makes logic more reusable especially in migration from frontend to DCR
