### PR TITLE
fix: Filter eventTimer properties with undefined values

### DIFF
--- a/src/sendCommercialMetrics.spec.ts
+++ b/src/sendCommercialMetrics.spec.ts
@@ -37,11 +37,7 @@ describe('sendCommercialMetrics', () => {
 					received_date: '2021-01-01',
 					platform: 'NEXT_GEN',
 					metrics: [],
-					properties: [
-						{ name: 'downlink', value: 'undefined' },
-						{ name: 'effectiveType', value: 'undefined' },
-						{ name: 'isDev', value: 'localhost' },
-					],
+					properties: [{ name: 'isDev', value: 'localhost' }],
 				}),
 			],
 		]);

--- a/src/sendCommercialMetrics.spec.ts
+++ b/src/sendCommercialMetrics.spec.ts
@@ -2,6 +2,12 @@ import MockDate from 'mockdate';
 import { EventTimer } from './EventTimer';
 import { sendCommercialMetrics } from './sendCommercialMetrics';
 
+const PROD_ENDPOINT =
+	'//performance-events.guardianapis.com/commercial-metrics';
+
+const DEV_ENDPOINT =
+	'//performance-events.code.dev-guardianapis.com/commercial-metrics';
+
 const DEFAULT_DATE = '2021-01-01T12:00:00.000Z';
 const PAGE_VIEW_ID = 'pv_id_1234567890';
 const BROWSER_ID = 'bwid_abcdefghijklm';
@@ -49,10 +55,7 @@ describe('sendCommercialMetrics', () => {
 		expect(mockSendMetrics()).toEqual(true);
 
 		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
-			[
-				'//performance-events.guardianapis.com/commercial-metrics',
-				JSON.stringify(defaultMetrics),
-			],
+			[PROD_ENDPOINT, JSON.stringify(defaultMetrics)],
 		]);
 	});
 
@@ -80,7 +83,7 @@ describe('sendCommercialMetrics', () => {
 
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 				[
-					'//performance-events.code.dev-guardianapis.com/commercial-metrics',
+					DEV_ENDPOINT,
 					JSON.stringify({
 						...defaultMetrics,
 						properties: [{ name: 'isDev', value: 'localhost' }],
@@ -104,7 +107,7 @@ describe('sendCommercialMetrics', () => {
 
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 				[
-					'//performance-events.guardianapis.com/commercial-metrics',
+					PROD_ENDPOINT,
 					JSON.stringify({
 						...defaultMetrics,
 						properties: [
@@ -135,7 +138,7 @@ describe('sendCommercialMetrics', () => {
 
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 				[
-					'//performance-events.code.dev-guardianapis.com/commercial-metrics',
+					DEV_ENDPOINT,
 					JSON.stringify({
 						...defaultMetrics,
 						properties: [

--- a/src/sendCommercialMetrics.ts
+++ b/src/sendCommercialMetrics.ts
@@ -21,6 +21,8 @@ type Properties = {
 	value: string;
 };
 
+type PropertyEntry = [string, string | number | undefined];
+
 export function sendCommercialMetrics(
 	pageViewId: string,
 	browserId: string | undefined,
@@ -41,6 +43,7 @@ export function sendCommercialMetrics(
 	const events = eventTimer.events;
 
 	const properties: Properties[] = Object.entries(eventTimer.properties)
+		.filter(([, value]: PropertyEntry) => value !== undefined)
 		.map((property) => {
 			const [name, value] = property;
 			return { name, value: String(value) };

--- a/src/sendCommercialMetrics.ts
+++ b/src/sendCommercialMetrics.ts
@@ -21,8 +21,6 @@ type Properties = {
 	value: string;
 };
 
-type PropertyEntry = [string, string | number | undefined];
-
 export function sendCommercialMetrics(
 	pageViewId: string,
 	browserId: string | undefined,
@@ -43,7 +41,7 @@ export function sendCommercialMetrics(
 	const events = eventTimer.events;
 
 	const properties: Properties[] = Object.entries(eventTimer.properties)
-		.filter(([, value]: PropertyEntry) => value !== undefined)
+		.filter(([, value]) => typeof value !== 'undefined')
 		.map((property) => {
 			const [name, value] = property;
 			return { name, value: String(value) };

--- a/src/sendCommercialMetrics.ts
+++ b/src/sendCommercialMetrics.ts
@@ -42,15 +42,13 @@ export function sendCommercialMetrics(
 
 	const properties: Properties[] = Object.entries(eventTimer.properties)
 		.filter(([, value]) => typeof value !== 'undefined')
-		.map((property) => {
-			const [name, value] = property;
-			return { name, value: String(value) };
-		})
+		.map(([name, value]) => ({ name, value: String(value) }))
 		.concat(devProperties);
 
-	const metrics: Metrics[] = events.map((event) => {
-		return { name: event.name, value: Math.ceil(event.ts) };
-	});
+	const metrics: Metrics[] = events.map(({ name, ts }) => ({
+		name,
+		value: Math.ceil(ts),
+	}));
 
 	const commercialMetrics: CommercialMetrics = {
 		browser_id: browserId,


### PR DESCRIPTION
## What does this change?

Filters event timer properties with undefined values.

~Also introduces a `PropertyEntry` type and annotation in order to prevent a [no-unnecessary-condition
](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md) eslint errror.~

## Why?

Prevents undefined properties being included and sent with commercial metrics.
