### PR TITLE
test: Additional unit tests for event timer, Inizio and Google Analytics

### DIFF
--- a/src/EventTimer.spec.ts
+++ b/src/EventTimer.spec.ts
@@ -5,21 +5,21 @@ jest.mock('./GoogleAnalytics', () => ({
 	trackEvent: jest.fn(),
 }));
 
+const performance = {
+	now: jest.fn(),
+	mark: jest.fn(),
+	getEntriesByName: jest.fn().mockReturnValue([
+		{
+			duration: 1,
+			entryType: 'mark',
+			name: 'commercial event',
+			startTime: 1,
+		},
+	]),
+};
+
 describe('EventTimer', () => {
 	beforeEach(() => {
-		const performance = {
-			now: jest.fn(),
-			mark: jest.fn(),
-			getEntriesByName: jest.fn().mockReturnValue([
-				{
-					duration: 1,
-					entryType: 'mark',
-					name: 'commercial event',
-					startTime: 1,
-				},
-			]),
-		};
-
 		Object.defineProperty(window, 'performance', {
 			configurable: true,
 			enumerable: true,

--- a/src/EventTimer.spec.ts
+++ b/src/EventTimer.spec.ts
@@ -6,27 +6,27 @@ jest.mock('./GoogleAnalytics', () => ({
 }));
 
 describe('EventTimer', () => {
-	const performance = {
-		now: jest.fn(),
-		mark: jest.fn(),
-		getEntriesByName: jest.fn().mockReturnValue([
-			{
-				duration: 1,
-				entryType: 'mark',
-				name: 'commercial event',
-				startTime: 1,
-			},
-		]),
-	};
-
-	Object.defineProperty(window, 'performance', {
-		configurable: true,
-		enumerable: true,
-		value: performance,
-		writable: true,
-	});
-
 	beforeEach(() => {
+		const performance = {
+			now: jest.fn(),
+			mark: jest.fn(),
+			getEntriesByName: jest.fn().mockReturnValue([
+				{
+					duration: 1,
+					entryType: 'mark',
+					name: 'commercial event',
+					startTime: 1,
+				},
+			]),
+		};
+
+		Object.defineProperty(window, 'performance', {
+			configurable: true,
+			enumerable: true,
+			value: performance,
+			writable: true,
+		});
+
 		window.guardian = {
 			config: {
 				googleAnalytics: {
@@ -38,6 +38,43 @@ describe('EventTimer', () => {
 		};
 
 		EventTimer.init();
+	});
+
+	it('mark produces correct event', () => {
+		const eventTimer = EventTimer.get();
+		eventTimer.mark('mark_name');
+		expect(eventTimer.events).toHaveLength(1);
+		expect(eventTimer.events[0].name).toBe('mark_name');
+		expect(eventTimer.events[0].ts).toBe(1);
+	});
+
+	it('calling mark with performance undefined produces no events', () => {
+		Object.defineProperty(window, 'performance', {
+			configurable: true,
+			enumerable: true,
+			value: undefined,
+			writable: true,
+		});
+		const eventTimer = EventTimer.get();
+		eventTimer.mark('mark_name');
+		expect(eventTimer.events).toEqual([]);
+	});
+
+	it('when retrieved mark is undefined produce no events', () => {
+		const performance = {
+			now: jest.fn(),
+			mark: jest.fn(),
+			getEntriesByName: jest.fn().mockReturnValue([]),
+		};
+		Object.defineProperty(window, 'performance', {
+			configurable: true,
+			enumerable: true,
+			value: performance,
+			writable: true,
+		});
+		const eventTimer = EventTimer.get();
+		eventTimer.mark('mark_name');
+		expect(eventTimer.events).toEqual([]);
 	});
 
 	it('trigger first slotReady event', () => {
@@ -54,6 +91,24 @@ describe('EventTimer', () => {
 		);
 	});
 
+	it('triggering two slotReady events causes one mark and one track', () => {
+		const eventTimer = EventTimer.get();
+		eventTimer.trigger('slotReady', 'inline1');
+		eventTimer.trigger('slotReady', 'inline1');
+
+		expect((window.performance.mark as jest.Mock).mock.calls).toEqual([
+			['gu.commercial.first-slotReady'],
+		]);
+
+		expect(trackEvent).toHaveBeenCalledTimes(1);
+
+		expect(trackEvent).toHaveBeenCalledWith(
+			'Commercial Events',
+			'slotReady',
+			'first-slotReady',
+		);
+	});
+
 	it('trigger top-above-nav slotReady event', () => {
 		const eventTimer = EventTimer.get();
 		eventTimer.trigger('slotReady', 'top-above-nav');
@@ -61,6 +116,24 @@ describe('EventTimer', () => {
 			['gu.commercial.first-slotReady'],
 			['gu.commercial.top-above-nav-slotReady'],
 		]);
+
+		expect((trackEvent as jest.Mock).mock.calls).toEqual([
+			['Commercial Events', 'slotReady', 'first-slotReady'],
+			['Commercial Events', 'slotReady', 'top-above-nav-slotReady'],
+		]);
+	});
+
+	it('trigger two top-above-nav slotReady events', () => {
+		const eventTimer = EventTimer.get();
+		eventTimer.trigger('slotReady', 'top-above-nav');
+		eventTimer.trigger('slotReady', 'top-above-nav');
+
+		expect((window.performance.mark as jest.Mock).mock.calls).toEqual([
+			['gu.commercial.first-slotReady'],
+			['gu.commercial.top-above-nav-slotReady'],
+		]);
+
+		expect(trackEvent).toHaveBeenCalledTimes(2);
 
 		expect((trackEvent as jest.Mock).mock.calls).toEqual([
 			['Commercial Events', 'slotReady', 'first-slotReady'],

--- a/src/GoogleAnalytics.spec.ts
+++ b/src/GoogleAnalytics.spec.ts
@@ -1,0 +1,83 @@
+import { trackEvent } from './GoogleAnalytics';
+
+// Set parameters to be used in tests
+const PERFORMANCE_NOW = 1;
+const TIMING_CATEGORY = 'TIMING_CATEGORY';
+const TIMING_VAR = 'TIMING_VAR';
+const TIMING_LABEL = 'TIMING_LABEL';
+const GUARDIAN_CONFIG = {
+	googleAnalytics: {
+		trackers: {
+			editorial: 'gaTrackerTest',
+		},
+	},
+};
+
+const ga = jest.fn();
+
+describe('trackEvent', () => {
+	beforeEach(() => {
+		window.performance.now = () => PERFORMANCE_NOW;
+	});
+
+	it('trackEvent makes no call to ga when ga undefined', () => {
+		window.guardian = {
+			config: GUARDIAN_CONFIG,
+		};
+		Object.defineProperty(window, 'ga', {
+			configurable: true,
+			enumerable: true,
+			value: undefined,
+			writable: true,
+		});
+		trackEvent(TIMING_CATEGORY, TIMING_VAR, TIMING_LABEL);
+		expect(ga.mock.calls.length).toBe(0);
+	});
+
+	it('trackEvent makes one call to ga with trackername from config', () => {
+		window.guardian = {
+			config: GUARDIAN_CONFIG,
+		};
+		Object.defineProperty(window, 'ga', {
+			configurable: true,
+			enumerable: true,
+			value: ga,
+			writable: true,
+		});
+		trackEvent(TIMING_CATEGORY, TIMING_VAR, TIMING_LABEL);
+		expect(ga.mock.calls.length).toBe(1);
+		expect(ga.mock.calls).toEqual([
+			[
+				'gaTrackerTest.send',
+				'timing',
+				TIMING_CATEGORY,
+				TIMING_VAR,
+				PERFORMANCE_NOW,
+				TIMING_LABEL,
+			],
+		]);
+	});
+	it('trackEvent makes one call to ga with default trackername when config undefined', () => {
+		window.guardian = {
+			config: undefined,
+		};
+		Object.defineProperty(window, 'ga', {
+			configurable: true,
+			enumerable: true,
+			value: ga,
+			writable: true,
+		});
+		trackEvent(TIMING_CATEGORY, TIMING_VAR, TIMING_LABEL);
+		expect(ga.mock.calls.length).toBe(1);
+		expect(ga.mock.calls).toEqual([
+			[
+				'send',
+				'timing',
+				TIMING_CATEGORY,
+				TIMING_VAR,
+				PERFORMANCE_NOW,
+				TIMING_LABEL,
+			],
+		]);
+	});
+});

--- a/src/third-party-tags/inizio.spec.ts
+++ b/src/third-party-tags/inizio.spec.ts
@@ -1,4 +1,4 @@
-import { handleQuerySurveyDone, inizio, onLoad } from './inizio';
+import { _, inizio } from './inizio';
 
 describe('index', () => {
 	it('should use the feature switch option', () => {
@@ -36,13 +36,13 @@ describe('handleQuerySurveyDone', () => {
 		});
 
 		it('setTargeting and logging called when survey available', () => {
-			handleQuerySurveyDone(true, { measurementId: 'xyz' });
+			_.handleQuerySurveyDone(true, { measurementId: 'xyz' });
 			expect(console.log).toHaveBeenCalledWith('surveyAvailable: xyz');
 			expect(setTargeting).toHaveBeenLastCalledWith('inizio', 't');
 		});
 
 		it('setTargeting and logging not called when survey not available', () => {
-			handleQuerySurveyDone(false, { measurementId: 'xyz' });
+			_.handleQuerySurveyDone(false, { measurementId: 'xyz' });
 			expect(console.log).toHaveBeenCalledTimes(0);
 			expect(setTargeting).toHaveBeenCalledTimes(0);
 		});
@@ -58,7 +58,7 @@ describe('handleQuerySurveyDone', () => {
 			});
 		});
 		it('survey available and setTargeting not called', () => {
-			handleQuerySurveyDone(true, { measurementId: 'xyz' });
+			_.handleQuerySurveyDone(true, { measurementId: 'xyz' });
 			expect(console.log).toHaveBeenCalledWith('surveyAvailable: xyz');
 			expect(setTargeting).toHaveBeenCalledTimes(0);
 		});
@@ -71,7 +71,7 @@ describe('onLoad', () => {
 	});
 
 	it('onLoad called populates _brandmetrics', () => {
-		onLoad();
+		_.onLoad();
 		expect(window._brandmetrics).toHaveLength(1);
 		expect(window._brandmetrics).toMatchObject([
 			{

--- a/src/third-party-tags/inizio.spec.ts
+++ b/src/third-party-tags/inizio.spec.ts
@@ -1,4 +1,4 @@
-import { inizio } from './inizio';
+import { handleQuerySurveyDone, inizio, onLoad } from './inizio';
 
 describe('index', () => {
 	it('should use the feature switch option', () => {
@@ -8,5 +8,75 @@ describe('index', () => {
 			url: '//cdn.brandmetrics.com/survey/script/e96d04c832084488a841a06b49b8fb2d.js',
 			name: 'inizio',
 		});
+	});
+});
+
+describe('handleQuerySurveyDone', () => {
+	console.log = jest.fn();
+	const setTargeting = jest.fn();
+
+	describe('mock googletag', () => {
+		beforeAll(() => {
+			const googletag = {
+				cmd: {
+					push: (callback: () => void) => {
+						callback();
+					},
+				},
+				pubads: () => ({
+					setTargeting,
+				}),
+			};
+			Object.defineProperty(window, 'googletag', {
+				configurable: true,
+				enumerable: true,
+				value: googletag,
+				writable: true,
+			});
+		});
+
+		it('setTargeting and logging called when survey available', () => {
+			handleQuerySurveyDone(true, { measurementId: 'xyz' });
+			expect(console.log).toHaveBeenCalledWith('surveyAvailable: xyz');
+			expect(setTargeting).toHaveBeenLastCalledWith('inizio', 't');
+		});
+
+		it('setTargeting and logging not called when survey available', () => {
+			handleQuerySurveyDone(false, { measurementId: 'xyz' });
+			expect(console.log).toHaveBeenCalledTimes(0);
+			expect(setTargeting).toHaveBeenCalledTimes(0);
+		});
+	});
+
+	describe('undefined googletag', () => {
+		beforeAll(() => {
+			Object.defineProperty(window, 'googletag', {
+				configurable: true,
+				enumerable: true,
+				value: undefined,
+				writable: true,
+			});
+		});
+		it('survey available and setTargeting not called', () => {
+			handleQuerySurveyDone(true, { measurementId: 'xyz' });
+			expect(console.log).toHaveBeenCalledWith('surveyAvailable: xyz');
+			expect(setTargeting).toHaveBeenCalledTimes(0);
+		});
+	});
+});
+
+describe('onLoad', () => {
+	it('onLoad not called leaves _brandmetrics undefined', () => {
+		expect(window._brandmetrics).toBe(undefined);
+	});
+
+	it('onLoad called populates _brandmetrics', () => {
+		onLoad();
+		expect(window._brandmetrics).toHaveLength(1);
+		expect(window._brandmetrics).toMatchObject([
+			{
+				cmd: '_querySurvey',
+			},
+		]);
 	});
 });

--- a/src/third-party-tags/inizio.spec.ts
+++ b/src/third-party-tags/inizio.spec.ts
@@ -41,7 +41,7 @@ describe('handleQuerySurveyDone', () => {
 			expect(setTargeting).toHaveBeenLastCalledWith('inizio', 't');
 		});
 
-		it('setTargeting and logging not called when survey available', () => {
+		it('setTargeting and logging not called when survey not available', () => {
 			handleQuerySurveyDone(false, { measurementId: 'xyz' });
 			expect(console.log).toHaveBeenCalledTimes(0);
 			expect(setTargeting).toHaveBeenCalledTimes(0);

--- a/src/third-party-tags/inizio.ts
+++ b/src/third-party-tags/inizio.ts
@@ -1,19 +1,20 @@
 import type { GetThirdPartyTag } from '../types';
 
-const onLoad = () => {
-	const handleQuerySurveyDone = (
-		surveyAvailable: boolean,
-		survey: { measurementId: string },
-	) => {
-		if (surveyAvailable) {
-			if (window.googletag) {
-				window.googletag.cmd.push(() => {
-					window.googletag?.pubads().setTargeting('inizio', 't');
-				});
-			}
-			console.log(`surveyAvailable: ${survey.measurementId}`);
+export const handleQuerySurveyDone = (
+	surveyAvailable: boolean,
+	survey: { measurementId: string },
+): void => {
+	if (surveyAvailable) {
+		if (window.googletag) {
+			window.googletag.cmd.push(() => {
+				window.googletag?.pubads().setTargeting('inizio', 't');
+			});
 		}
-	};
+		console.log(`surveyAvailable: ${survey.measurementId}`);
+	}
+};
+
+export const onLoad = (): void => {
 	window._brandmetrics ||= [];
 	window._brandmetrics.push({
 		cmd: '_querySurvey',

--- a/src/third-party-tags/inizio.ts
+++ b/src/third-party-tags/inizio.ts
@@ -1,6 +1,6 @@
 import type { GetThirdPartyTag } from '../types';
 
-export const handleQuerySurveyDone = (
+const handleQuerySurveyDone = (
 	surveyAvailable: boolean,
 	survey: { measurementId: string },
 ): void => {
@@ -14,7 +14,7 @@ export const handleQuerySurveyDone = (
 	}
 };
 
-export const onLoad = (): void => {
+const onLoad = (): void => {
 	window._brandmetrics ||= [];
 	window._brandmetrics.push({
 		cmd: '_querySurvey',
@@ -30,3 +30,8 @@ export const inizio: GetThirdPartyTag = ({ shouldRun }) => ({
 	name: 'inizio',
 	onLoad,
 });
+
+export const _ = {
+	onLoad,
+	handleQuerySurveyDone,
+};


### PR DESCRIPTION
## What does this change?

This PR adds:
- Additional unit tests to EventTimer, testing multiple events and `mark`.
- Additional unit tests to the Inizio third party tag.
- Unit tests for google analytics.

## Why?

Increase code coverage!