### PR TITLE
fix: Stop sending date for Commercial Metrics

### DIFF
--- a/src/sendCommercialMetrics.ts
+++ b/src/sendCommercialMetrics.ts
@@ -35,6 +35,7 @@ export function sendCommercialMetrics(
 		: '//performance-events.guardianapis.com/commercial-metrics';
 	if (document.visibilityState !== 'hidden') return false;
 
+	// TODO: remove this
 	const timestamp = new Date().toISOString();
 	const date = timestamp.slice(0, 10);
 	const eventTimer = EventTimer.get();


### PR DESCRIPTION
## What does this change?

Stops sending `received_date` and `received_timestamp` when calling `sendCommercialMetrics`.

## Why?

This is now handled server-side and is already being removed. We don’t need to send any more data.
