### PR TITLE
fix: Stop sending client-side date metrics

### DIFF
--- a/src/sendCommercialMetrics.spec.ts
+++ b/src/sendCommercialMetrics.spec.ts
@@ -8,15 +8,12 @@ const PROD_ENDPOINT =
 const DEV_ENDPOINT =
 	'//performance-events.code.dev-guardianapis.com/commercial-metrics';
 
-const DEFAULT_DATE = '2021-01-01T12:00:00.000Z';
 const PAGE_VIEW_ID = 'pv_id_1234567890';
 const BROWSER_ID = 'bwid_abcdefghijklm';
 
 const defaultMetrics = {
 	browser_id: BROWSER_ID,
 	page_view_id: PAGE_VIEW_ID,
-	received_timestamp: DEFAULT_DATE,
-	received_date: DEFAULT_DATE.substr(0, 10), // 2021-01-01
 	platform: 'NEXT_GEN',
 	metrics: [],
 	properties: [],
@@ -33,14 +30,6 @@ const setVisibility = (value: 'hidden' | 'visible' = 'hidden'): void => {
 };
 
 describe('sendCommercialMetrics', () => {
-	beforeAll(() => {
-		MockDate.set(DEFAULT_DATE);
-	});
-
-	afterAll(() => {
-		MockDate.reset();
-	});
-
 	const sendBeacon = jest.fn().mockReturnValue(true);
 	Object.defineProperty(navigator, 'sendBeacon', {
 		configurable: true,

--- a/src/sendCommercialMetrics.spec.ts
+++ b/src/sendCommercialMetrics.spec.ts
@@ -1,4 +1,3 @@
-import MockDate from 'mockdate';
 import { EventTimer } from './EventTimer';
 import { sendCommercialMetrics } from './sendCommercialMetrics';
 

--- a/src/sendCommercialMetrics.ts
+++ b/src/sendCommercialMetrics.ts
@@ -4,8 +4,6 @@ import { EventTimer } from './EventTimer';
 type CommercialMetrics = {
 	browser_id?: string;
 	page_view_id: string;
-	received_timestamp: string;
-	received_date: string;
 	platform: string;
 	metrics: Metrics[];
 	properties: Properties[];
@@ -35,8 +33,6 @@ export function sendCommercialMetrics(
 		: '//performance-events.guardianapis.com/commercial-metrics';
 	if (document.visibilityState !== 'hidden') return false;
 
-	const timestamp = new Date().toISOString();
-	const date = timestamp.slice(0, 10);
 	const eventTimer = EventTimer.get();
 	const events = eventTimer.events;
 
@@ -53,8 +49,6 @@ export function sendCommercialMetrics(
 	const commercialMetrics: CommercialMetrics = {
 		browser_id: browserId,
 		page_view_id: pageViewId,
-		received_timestamp: timestamp,
-		received_date: date,
 		platform: 'NEXT_GEN',
 		metrics,
 		properties,


### PR DESCRIPTION
## What does this change?

Stop sending `received_timestamp` and `received_date` as part of commercial metrics.

## Why?

Commercial metrics will receive timestamps server-side (see https://github.com/guardian/fastly-edge-cache/pull/911).
