### PR TITLE
docs: update coverage and remove bundlephobia link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # @guardian/commercial-core
 
 [![npm (scoped)](https://img.shields.io/npm/v/@guardian/commercial-core)](https://www.npmjs.com/package/@guardian/commercial-core)
-[![minzipped (scoped)](https://badgen.net/bundlephobia/minzip/@guardian/commercial-core)](https://bundlephobia.com/result?p=@guardian/commercial-core)
 [![ES version](https://badgen.net/badge/ES/2020/cyan)](https://tc39.es/ecma262/2020/)
 [![npm type definitions](https://img.shields.io/npm/types/@guardian/commercial-core)](https://www.typescriptlang.org/)
-[![Coverage Status](https://coveralls.io/repos/github/guardian/commercial-core/badge.svg)](https://coveralls.io/github/guardian/commercial-core)
+[![Coverage Status](https://coveralls.io/repos/github/guardian/commercial-core/badge.svg?branch=main)](https://coveralls.io/github/guardian/commercial-core?branch=main)
 
 > Guardian advertising business logic
 


### PR DESCRIPTION
## What does this change?

Updates the ReadMe.

## Why?

- We now have 100% coverage, and coveralls wasn’t picking up the main branch, it seemed
- We don’t release a cjs module, so bundlephobia cannot do its thing.