### PR TITLE
feat: Include CMP events in EventTimer

### DIFF
--- a/src/EventTimer.spec.ts
+++ b/src/EventTimer.spec.ts
@@ -35,6 +35,11 @@ const performance = {
 		.mockReturnValue([]),
 };
 
+const MARK_NAME = 'mark_name';
+const MARK_LONG_NAME = `gu.commercial.${MARK_NAME}`;
+const CMP_INIT = 'cmp-tcfv2-init';
+const CMP_GOT_CONSENT = 'cmp-tcfv2-got-consent';
+
 describe('EventTimer', () => {
 	beforeEach(() => {
 		Object.defineProperty(window, 'performance', {
@@ -61,10 +66,7 @@ describe('EventTimer', () => {
 		const performanceCMP = {
 			now: jest.fn(),
 			mark: jest.fn(),
-			getEntriesByName: mockGetEntriesByName([
-				'cmp-tcfv2-init',
-				'cmp-tcfv2-got-consent',
-			]),
+			getEntriesByName: mockGetEntriesByName([CMP_INIT, CMP_GOT_CONSENT]),
 		};
 		Object.defineProperty(window, 'performance', {
 			configurable: true,
@@ -74,8 +76,8 @@ describe('EventTimer', () => {
 		});
 		const eventTimer = EventTimer.get();
 		expect(eventTimer.events).toHaveLength(2);
-		expect(eventTimer.events.map((event) => event.name)).toEqual(
-			expect.arrayContaining(['cmp-tcfv2-init', 'cmp-tcfv2-init']),
+		expect(eventTimer.events.map((event) => event.name).sort()).toEqual(
+			[CMP_GOT_CONSENT, CMP_INIT].sort(),
 		);
 	});
 
@@ -84,9 +86,9 @@ describe('EventTimer', () => {
 			now: jest.fn(),
 			mark: jest.fn(),
 			getEntriesByName: mockGetEntriesByName([
-				'gu.commercial.mark_name',
-				'cmp-tcfv2-init',
-				'cmp-tcfv2-got-consent',
+				MARK_LONG_NAME,
+				CMP_INIT,
+				CMP_GOT_CONSENT,
 			]),
 		};
 		Object.defineProperty(window, 'performance', {
@@ -96,22 +98,18 @@ describe('EventTimer', () => {
 			writable: true,
 		});
 		const eventTimer = EventTimer.get();
-		eventTimer.mark('mark_name');
+		eventTimer.mark(MARK_NAME);
 		expect(eventTimer.events).toHaveLength(3);
-		expect(eventTimer.events.map((event) => event.name)).toEqual(
-			expect.arrayContaining([
-				'cmp-tcfv2-init',
-				'cmp-tcfv2-got-consent',
-				'mark_name',
-			]),
+		expect(eventTimer.events.map((event) => event.name).sort()).toEqual(
+			[CMP_INIT, CMP_GOT_CONSENT, MARK_NAME].sort(),
 		);
 	});
 
 	it('mark produces correct event', () => {
 		const eventTimer = EventTimer.get();
-		eventTimer.mark('mark_name');
+		eventTimer.mark(MARK_NAME);
 		expect(eventTimer.events).toHaveLength(1);
-		expect(eventTimer.events[0].name).toBe('mark_name');
+		expect(eventTimer.events[0].name).toBe(MARK_NAME);
 		expect(eventTimer.events[0].ts).toBe(1);
 	});
 
@@ -123,7 +121,7 @@ describe('EventTimer', () => {
 			writable: true,
 		});
 		const eventTimer = EventTimer.get();
-		eventTimer.mark('mark_name');
+		eventTimer.mark(MARK_NAME);
 		expect(eventTimer.events).toEqual([]);
 	});
 
@@ -140,7 +138,7 @@ describe('EventTimer', () => {
 			writable: true,
 		});
 		const eventTimer = EventTimer.get();
-		eventTimer.mark('mark_name');
+		eventTimer.mark(MARK_NAME);
 		expect(eventTimer.events).toEqual([]);
 	});
 

--- a/src/EventTimer.spec.ts
+++ b/src/EventTimer.spec.ts
@@ -8,14 +8,24 @@ jest.mock('./GoogleAnalytics', () => ({
 const performance = {
 	now: jest.fn(),
 	mark: jest.fn(),
-	getEntriesByName: jest.fn().mockReturnValue([
-		{
-			duration: 1,
-			entryType: 'mark',
-			name: 'commercial event',
-			startTime: 1,
-		},
-	]),
+	getEntriesByName: jest
+		.fn()
+		.mockReturnValueOnce([
+			{
+				duration: 1,
+				entryType: 'mark',
+				name: 'commercial event',
+				startTime: 1,
+			},
+		])
+		.mockReturnValue([
+			{
+				duration: 1,
+				entryType: 'mark',
+				name: 'commercial event',
+				startTime: 0,
+			},
+		]),
 };
 
 describe('EventTimer', () => {

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -95,7 +95,7 @@ export class EventTimer {
 									eventName,
 									window.performance.getEntriesByName(
 										eventName,
-									)[0],
+									)[0] as PerformanceEntry,
 								),
 						),
 			  ]

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -95,7 +95,7 @@ export class EventTimer {
 						)
 						.filter((event) => event.ts > 0),
 			  ]
-			: [...this._events];
+			: this._events;
 	}
 
 	constructor() {

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -32,7 +32,15 @@ interface PageEventStatus {
 }
 
 export class EventTimer {
-	events: Event[];
+	private _events: Event[];
+	private static _externallyDefinedEventNames = [
+		'cmp-tcfv2-init',
+		'cmp-tcfv2-got-consent',
+		'cmp-ccpa-init',
+		'cmp-ccpa-got-consent',
+		'cmp-aus-init',
+		'cmp-aus-got-consent',
+	];
 	startTS: DOMHighResTimeStamp;
 	triggers: {
 		first: SlotEventStatus;
@@ -66,8 +74,32 @@ export class EventTimer {
 		return this.init();
 	}
 
+	/**
+	 * Returns all commercial timers. CMP-related timers are not tracked
+	 * by EventTimer so they need to be concatenated to EventTimer's private events array.
+	 */
+	public get events(): Event[] {
+		return typeof window.performance !== 'undefined' &&
+			'mark' in window.performance
+			? [
+					...this._events,
+					...EventTimer._externallyDefinedEventNames
+						.map(
+							(eventName) =>
+								new Event(
+									eventName,
+									window.performance.getEntriesByName(
+										eventName,
+									)[0] ?? 0,
+								),
+						)
+						.filter((event) => event.ts > 0),
+			  ]
+			: [...this._events];
+	}
+
 	constructor() {
-		this.events = [];
+		this._events = [];
 		this.startTS = window.performance.now();
 		this.triggers = {
 			first: {
@@ -127,7 +159,7 @@ export class EventTimer {
 				.getEntriesByName(longName, 'mark')
 				.slice(-1)[0];
 			if (typeof mark !== 'undefined') {
-				this.events.push(new Event(name, mark));
+				this._events.push(new Event(name, mark));
 			}
 		}
 	}

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -84,16 +84,20 @@ export class EventTimer {
 			? [
 					...this._events,
 					...EventTimer._externallyDefinedEventNames
+						.filter(
+							(eventName) =>
+								window.performance.getEntriesByName(eventName)
+									.length,
+						)
 						.map(
 							(eventName) =>
 								new Event(
 									eventName,
 									window.performance.getEntriesByName(
 										eventName,
-									)[0] ?? 0,
+									)[0],
 								),
-						)
-						.filter((event) => event.ts > 0),
+						),
 			  ]
 			: this._events;
 	}

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -80,7 +80,7 @@ export class EventTimer {
 	 */
 	public get events(): Event[] {
 		return typeof window.performance !== 'undefined' &&
-			'mark' in window.performance
+			'getEntriesByName' in window.performance
 			? [
 					...this._events,
 					...EventTimer._externallyDefinedEventNames


### PR DESCRIPTION
Co-authored-by: Chris Jones <christopher.jones@guardian.co.uk>

## What does this change?
This change adds CMP-related timers to `EventTimer`, allowing us to send SourcePoint timers to the data lake.

CMP events are not tracked by `EventTimer`'s `trigger` function (see example [here](https://github.com/guardian/consent-management-platform/blob/c404fd68dc629525f4a70e25dfc97fc419a1eb97/src/tcfv2/sourcepoint.ts#L46)), so a static array including CMP event names has been added to to the fields of the `EventTimer` class, as well as a getter function that concatenates `EventTimer`'s private events to the external consent timers.

The tracked events are:
- `cmp-[framework]-init`
-  `cmp-[framework]-got-consent`

where `[framework]` is one of `tcfv2`, `ccpa`, or `aus`. 

Because CMP events are now included in `EventTimer`, no changes are needed to `sendCommercialMetrics`, so we will start seeing these new metrics flow into the lake when this PR is merged.

## Why?
Tracking CMP timers will give us a better understanding of how SP metrics relate to commercial timers.