### PR TITLE
refactor: Enable --noUncheckedIndexedAccess typescript flag

### DIFF
--- a/src/EventTimer.spec.ts
+++ b/src/EventTimer.spec.ts
@@ -44,8 +44,8 @@ describe('EventTimer', () => {
 		const eventTimer = EventTimer.get();
 		eventTimer.mark('mark_name');
 		expect(eventTimer.events).toHaveLength(1);
-		expect(eventTimer.events[0].name).toBe('mark_name');
-		expect(eventTimer.events[0].ts).toBe(1);
+		expect(eventTimer.events[0]?.name).toBe('mark_name');
+		expect(eventTimer.events[0]?.ts).toBe(1);
 	});
 
 	it('calling mark with performance undefined produces no events', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+	"noUncheckedIndexedAccess": true,
     "allowJs": true,
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Enable the `--noUncheckedIndexedAccess` flag and fix occurrences where indexed access now gives type errors.

More info is included in the [tsconfig documentation](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess).

## Why?

Indexed accesses are typed as being possibly undefined, requiring explicit checking of whether values are undefined. For example:
```
const x = [1, 2, 3][3];
```
When the flag is not enabled this is typed as `x: number` even though its value is `undefined`. When the flag is enabled
`x: number | undefined` and requires more explicit handling of the `undefined` case in the code.
