### PR TITLE
fix: Error when window.ga is unavailable.

### DIFF
--- a/src/GoogleAnalytics.ts
+++ b/src/GoogleAnalytics.ts
@@ -6,7 +6,8 @@ export const trackEvent = (
 	const { ga, guardian } = window;
 	const trackerName: string | undefined =
 		guardian.config?.googleAnalytics?.trackers.editorial;
-	if (typeof ga === 'undefined') {
+
+	if (typeof ga !== 'function') {
 		return;
 	}
 	const timeSincePageLoad: number = Math.round(window.performance.now());


### PR DESCRIPTION
Sometimes window.ga is null, not undefined, and this previously caused a problem.

## What does this change?
Checks if window.ga is a function, instead of checking if it's not undefined.

## Why?
In some circumstance it appears that window.ga is set to null, when CCPA opt-out is applied, for example.
