### PR TITLE
fix: Isolate global types from package

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -1,8 +1,9 @@
 import type {
 	GoogleTagParams,
 	GoogleTrackConversionObject,
-	GuardianCommercial,
+	GuardianWindowConfig,
 } from './types';
+import type { EventTimer } from '.';
 
 declare global {
 	interface Navigator {
@@ -19,7 +20,10 @@ declare global {
 			val: Record<string, unknown>;
 		}>;
 		googletag?: googletag.Googletag;
-		guardian: GuardianCommercial;
+		guardian: {
+			commercialTimer?: EventTimer;
+			config?: GuardianWindowConfig;
+		};
 		ga: UniversalAnalytics.ga | null;
 		readonly navigator: Navigator;
 	}

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,0 +1,26 @@
+import type {
+	GoogleTagParams,
+	GoogleTrackConversionObject,
+	GuardianCommercial,
+} from './types';
+
+declare global {
+	interface Navigator {
+		connection?: {
+			downlink: number;
+			effectiveType: string;
+		};
+	}
+	interface Window {
+		google_trackConversion?: (arg0: GoogleTrackConversionObject) => void;
+		google_tag_params?: GoogleTagParams;
+		_brandmetrics?: Array<{
+			cmd: string;
+			val: Record<string, unknown>;
+		}>;
+		googletag?: googletag.Googletag;
+		guardian: GuardianCommercial;
+		ga: UniversalAnalytics.ga | null;
+		readonly navigator: Navigator;
+	}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,9 +24,9 @@ export type GuardianAnalyticsConfig = {
 	trackers: Record<string, string>;
 };
 
-export type GuardianWindowConfig = {
+export interface GuardianWindowConfig {
 	googleAnalytics?: GuardianAnalyticsConfig;
-};
+}
 
 export type GoogleTagParams = unknown;
 export type GoogleTrackConversionObject = {
@@ -35,26 +35,8 @@ export type GoogleTrackConversionObject = {
 	google_remarketing_only: boolean;
 };
 
-declare global {
-	interface Navigator {
-		connection?: {
-			downlink: number;
-			effectiveType: string;
-		};
-	}
-	interface Window {
-		google_trackConversion?: (arg0: GoogleTrackConversionObject) => void;
-		google_tag_params?: GoogleTagParams;
-		_brandmetrics?: Array<{
-			cmd: string;
-			val: Record<string, unknown>;
-		}>;
-		googletag?: googletag.Googletag;
-		guardian: {
-			commercialTimer?: EventTimer;
-			config?: GuardianWindowConfig;
-		};
-		ga: UniversalAnalytics.ga;
-		readonly navigator: Navigator;
-	}
+export interface GuardianCommercial {
+	commercialTimer?: EventTimer;
+	config?: GuardianWindowConfig;
+	[x: string]: unknown;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,5 +38,4 @@ export type GoogleTrackConversionObject = {
 export interface GuardianCommercial {
 	commercialTimer?: EventTimer;
 	config?: GuardianWindowConfig;
-	[x: string]: unknown;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,9 +24,9 @@ export type GuardianAnalyticsConfig = {
 	trackers: Record<string, string>;
 };
 
-export interface GuardianWindowConfig {
+export type GuardianWindowConfig = {
 	googleAnalytics?: GuardianAnalyticsConfig;
-}
+};
 
 export type GoogleTagParams = unknown;
 export type GoogleTrackConversionObject = {
@@ -34,8 +34,3 @@ export type GoogleTrackConversionObject = {
 	google_custom_params: GoogleTagParams;
 	google_remarketing_only: boolean;
 };
-
-export interface GuardianCommercial {
-	commercialTimer?: EventTimer;
-	config?: GuardianWindowConfig;
-}


### PR DESCRIPTION
## What does this change?

Move global types to a separate file, so they don’t get packaged.

## Why?

This prevents clashing when trying to import this package in [`dotcom-rendering`](https://github.com/guardian/dotcom-rendering/pull/3152).