### PR TITLE
fix: Migrate from `@guardian/types` to `@guardian/libs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@guardian/eslint-config-typescript": "^0.6",
     "@guardian/libs": "^3",
     "@guardian/prettier": "^0.6",
-    "@guardian/types": "^8",
     "@octokit/core": "^3",
     "@semantic-release/github": "^7",
     "@types/doubleclick-gpt": "^2019111201.0.0",
@@ -75,7 +74,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@guardian/libs": "^3",
-    "@guardian/types": "^6"
+    "@guardian/libs": "^3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -497,11 +497,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.6.0.tgz#b3dcbef0e2a9232d2afe04dff075426b2939f44e"
   integrity sha512-RN8GBRth5BXHoWymCZIYDbmZM8DkUbgecf+wyv+9hdXA/ad4Ob4qP9u/ARU689qMo+JSC1z3FRKelvkkjtYzJw==
 
-"@guardian/types@^8":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-8.1.0.tgz#520e16d93c1a8f2bf36c8f4faff5bea81fb9346d"
-  integrity sha512-6qpQxHW+DwvJqc4aPrWIN0GoErTN8R+WlQ4Cq/NJKiIWROvgOytC4P/2hiLNxoEpla93cT56293Fd1cYRUhnPA==
-
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"


### PR DESCRIPTION
## What does this change?

This PR migrates from the [`@guardian/types`](https://github.com/guardian/types) library to [`@guardian/libs`](https://github.com/guardian/libs) as [`@guardian/types` is now deprecated](https://github.com/guardian/types/pull/140).

For this repository, that simply means dropping `@guardian/types` from both `devDependencies` and `peerDependencies` as it wasn't being used anywhere.

## How to test

Run all validation and ensure that everything still runs as expected.