### PR TITLE
feat: Migrate ad size definitions to commercial core

### DIFF
--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -1,0 +1,20 @@
+import { _ } from './ad-sizes';
+
+const { getAdSize } = _;
+
+describe('ad sizes', () => {
+	it.each([
+		[getAdSize(2, 2), 2, 2, '2,2'],
+		[getAdSize(100, 100), 100, 100, '100,100'],
+		[getAdSize(320, 50), 320, 50, '320,50'],
+		[getAdSize(970, 250), 970, 250, '970,250'],
+		[getAdSize(0, 0), 0, 0, 'fluid'],
+	])(
+		'getAdSizes outputs correct values',
+		(adSize, expectedWidth, expectedHeight, expectedString) => {
+			expect(adSize.width).toEqual(expectedWidth);
+			expect(adSize.height).toEqual(expectedHeight);
+			expect(adSize.toString()).toEqual(expectedString);
+		},
+	);
+});

--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -4,14 +4,15 @@ const { getAdSize } = _;
 
 describe('ad sizes', () => {
 	it.each([
-		[getAdSize(2, 2), 2, 2, '2,2'],
-		[getAdSize(100, 100), 100, 100, '100,100'],
-		[getAdSize(320, 50), 320, 50, '320,50'],
-		[getAdSize(970, 250), 970, 250, '970,250'],
-		[getAdSize(0, 0), 0, 0, 'fluid'],
+		[2, 2, 2, 2, '2,2'],
+		[100, 100, 100, 100, '100,100'],
+		[320, 50, 320, 50, '320,50'],
+		[970, 250, 970, 250, '970,250'],
+		[0, 0, 0, 0, 'fluid'],
 	])(
-		'getAdSizes outputs correct values',
-		(adSize, expectedWidth, expectedHeight, expectedString) => {
+		'getAdSize(%d,%d) outputs width %d, height %d, string %s',
+		(width, height, expectedWidth, expectedHeight, expectedString) => {
+			const adSize = getAdSize(width, height);
 			expect(adSize.width).toEqual(expectedWidth);
 			expect(adSize.height).toEqual(expectedHeight);
 			expect(adSize.toString()).toEqual(expectedString);

--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -4,15 +4,15 @@ const { getAdSize } = _;
 
 describe('ad sizes', () => {
 	it.each([
-		[2, 2, 2, 2, '2,2'],
-		[100, 100, 100, 100, '100,100'],
-		[320, 50, 320, 50, '320,50'],
-		[970, 250, 970, 250, '970,250'],
-		[0, 0, 0, 0, 'fluid'],
+		[2, 2, '2,2'],
+		[100, 100, '100,100'],
+		[320, 50, '320,50'],
+		[970, 250, '970,250'],
+		[0, 0, 'fluid'],
 	])(
-		'getAdSize(%d,%d) outputs width %d, height %d, string %s',
-		(width, height, expectedWidth, expectedHeight, expectedString) => {
-			const adSize = getAdSize(width, height);
+		'getAdSize(%d,%d) outputs string "%s"',
+		(expectedWidth, expectedHeight, expectedString) => {
+			const adSize = getAdSize(expectedWidth, expectedHeight);
 			expect(adSize.width).toEqual(expectedWidth);
 			expect(adSize.height).toEqual(expectedHeight);
 			expect(adSize.toString()).toEqual(expectedString);

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -1,0 +1,87 @@
+export type GuAdSizeString = 'fluid' | `${number},${number}`;
+
+export type GuAdSize = Readonly<{
+	width: number;
+	height: number;
+	toString: () => GuAdSizeString;
+}>;
+
+export type SizeKeys =
+	| 'billboard'
+	| 'leaderboard'
+	| 'mpu'
+	| 'halfPage'
+	| 'portrait'
+	| 'skyscraper'
+	| 'mobilesticky'
+	| 'fluid'
+	| 'outOfPage'
+	| 'googleCard'
+	| 'video'
+	| 'outstreamDesktop'
+	| 'outstreamGoogleDesktop'
+	| 'outstreamMobile'
+	| 'merchandisingHighAdFeature'
+	| 'merchandisingHigh'
+	| 'merchandising'
+	| 'inlineMerchandising'
+	| 'fabric'
+	| 'empty'
+	| '970x250'
+	| '728x90'
+	| '300x250'
+	| '300x600'
+	| '300x1050'
+	| '160x600';
+
+const getAdSize = (width: number, height: number): GuAdSize => {
+	const toString = (): GuAdSizeString =>
+		width === 0 && height === 0 ? 'fluid' : `${width},${height}`;
+
+	return Object.freeze({
+		width,
+		height,
+		toString,
+	});
+};
+
+const adSizesPartial = {
+	// standard ad sizes
+	billboard: getAdSize(970, 250),
+	leaderboard: getAdSize(728, 90),
+	mpu: getAdSize(300, 250),
+	halfPage: getAdSize(300, 600),
+	portrait: getAdSize(300, 1050),
+	skyscraper: getAdSize(160, 600),
+	mobilesticky: getAdSize(320, 50),
+
+	// dfp proprietary ad sizes
+	fluid: getAdSize(0, 0),
+	outOfPage: getAdSize(1, 1),
+	googleCard: getAdSize(300, 274),
+
+	// guardian proprietary ad sizes
+	video: getAdSize(620, 1),
+	outstreamDesktop: getAdSize(620, 350),
+	outstreamGoogleDesktop: getAdSize(550, 310),
+	outstreamMobile: getAdSize(300, 197),
+	merchandisingHighAdFeature: getAdSize(88, 89),
+	merchandisingHigh: getAdSize(88, 87),
+	merchandising: getAdSize(88, 88),
+	inlineMerchandising: getAdSize(88, 85),
+	fabric: getAdSize(88, 71),
+	empty: getAdSize(2, 2),
+};
+
+export const adSizes: Record<SizeKeys, GuAdSize> = {
+	...adSizesPartial,
+	'970x250': adSizesPartial.billboard,
+	'728x90': adSizesPartial.leaderboard,
+	'300x250': adSizesPartial.mpu,
+	'300x600': adSizesPartial.halfPage,
+	'300x1050': adSizesPartial.portrait,
+	'160x600': adSizesPartial.skyscraper,
+};
+
+// Export for testing
+export const _ = { getAdSize };

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -1,9 +1,9 @@
-export type GuAdSizeString = 'fluid' | `${number},${number}`;
+export type AdSizeString = 'fluid' | `${number},${number}`;
 
-export type GuAdSize = Readonly<{
+export type AdSize = Readonly<{
 	width: number;
 	height: number;
-	toString: () => GuAdSizeString;
+	toString: () => AdSizeString;
 }>;
 
 export type SizeKeys =
@@ -34,8 +34,8 @@ export type SizeKeys =
 	| '300x1050'
 	| '160x600';
 
-const getAdSize = (width: number, height: number): GuAdSize => {
-	const toString = (): GuAdSizeString =>
+const getAdSize = (width: number, height: number): AdSize => {
+	const toString = (): AdSizeString =>
 		width === 0 && height === 0 ? 'fluid' : `${width},${height}`;
 
 	return Object.freeze({
@@ -73,7 +73,7 @@ const adSizesPartial = {
 	empty: getAdSize(2, 2),
 };
 
-export const adSizes: Record<SizeKeys, GuAdSize> = {
+export const adSizes: Record<SizeKeys, AdSize> = {
 	...adSizesPartial,
 	'970x250': adSizesPartial.billboard,
 	'728x90': adSizesPartial.leaderboard,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,5 @@ export { remarketing } from './third-party-tags/remarketing';
 export { EventTimer } from './EventTimer';
 export { sendCommercialMetrics } from './sendCommercialMetrics';
 export type { ThirdPartyTag } from './types';
+export { adSizes } from './ad-sizes';
+export type { SizeKeys, AdSizeString, AdSize } from './ad-sizes';


### PR DESCRIPTION
## What does this change?

Migrate the size definitions that are currently defined separately in [frontend](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/commercial/modules/ad-sizes.js) and [DCR](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/components/AdSlot.tsx) to commercial core.

## Why?

- Frontend and DCR size definitions won't need to be manually kept in sync.
- These are important definitions that can be appropriately documented here.
- One of the first steps in a longer-term goal to move commercial code out of frontend.