### PR TITLE
chore(tests): set testEnvironment globally

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
 	collectCoverage: true,
 	collectCoverageFrom: ['src/**/*'],
 	coveragePathIgnorePatterns: ['vendor'],
+	testEnvironment: 'jsdom',
 };

--- a/src/EventTimer.spec.ts
+++ b/src/EventTimer.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { EventTimer } from './EventTimer';
 import { trackEvent } from './GoogleAnalytics';
 

--- a/src/GoogleAnalytics.spec.ts
+++ b/src/GoogleAnalytics.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { trackEvent } from './GoogleAnalytics';
 
 // Set parameters to be used in tests

--- a/src/sendCommercialMetrics.spec.ts
+++ b/src/sendCommercialMetrics.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { EventTimer } from './EventTimer';
 import { sendCommercialMetrics } from './sendCommercialMetrics';
 

--- a/src/third-party-tags/inizio.spec.ts
+++ b/src/third-party-tags/inizio.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { _, inizio } from './inizio';
 
 describe('index', () => {

--- a/src/third-party-tags/remarketing.spec.ts
+++ b/src/third-party-tags/remarketing.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import type { ThirdPartyTag } from '../types';
 import { remarketing } from './remarketing';
 


### PR DESCRIPTION
## What does this change?

All our unit tests are meant to be running in the browser, so we set `testEnvironment` to `jsdom` in the Jest config.