### PR TITLE
fix: Handle case where `window.performance = undefined`

### DIFF
--- a/src/GoogleAnalytics.spec.ts
+++ b/src/GoogleAnalytics.spec.ts
@@ -34,6 +34,27 @@ describe('trackEvent', () => {
 		expect(ga.mock.calls.length).toBe(0);
 	});
 
+	it('trackEvent makes no call to ga when window.performance is undefined', () => {
+		const performance = window.performance;
+
+		Object.defineProperty(window, 'performance', {
+			configurable: true,
+			enumerable: true,
+			value: undefined,
+			writable: true,
+		});
+
+		trackEvent(TIMING_CATEGORY, TIMING_VAR, TIMING_LABEL);
+		expect(ga.mock.calls.length).toBe(0);
+
+		Object.defineProperty(window, 'performance', {
+			configurable: true,
+			enumerable: true,
+			value: performance,
+			writable: true,
+		});
+	});
+
 	it('trackEvent makes one call to ga with trackername from config', () => {
 		window.guardian = {
 			config: GUARDIAN_CONFIG,

--- a/src/GoogleAnalytics.ts
+++ b/src/GoogleAnalytics.ts
@@ -3,14 +3,14 @@ export const trackEvent = (
 	timingVar: string,
 	timingLabel: string,
 ): void => {
-	const { ga, guardian } = window;
+	const { ga, guardian, performance } = window;
 	const trackerName: string | undefined =
 		guardian.config?.googleAnalytics?.trackers.editorial;
 
-	if (typeof ga !== 'function') {
+	if (typeof ga !== 'function' || typeof performance == 'undefined') {
 		return;
 	}
-	const timeSincePageLoad: number = Math.round(window.performance.now());
+	const timeSincePageLoad: number = Math.round(performance.now());
 
 	const send = trackerName ? `${trackerName}.send` : 'send';
 	window.ga(


### PR DESCRIPTION
## What does this change?

[Some older browsers don't support the Performance API](https://developer.mozilla.org/en-US/docs/Web/API/Performance#browser_compatibility). Mostly we guard against this case by checking if `window.performance` is `undefined` before calling methods on it, but we discovered one instance where this wasn't happening, so we fixed it.

## Why?

We believe this to be the cause of a number of [Sentry errors](https://sentry.io/organizations/the-guardian/issues/?groupStatsPeriod=24h&project=35463&query=is%3Aunresolved++window.performance&sort=freq)