### PR TITLE
feat: Detect ad blockers

### DIFF
--- a/src/detectAdBlocker.ts
+++ b/src/detectAdBlocker.ts
@@ -3,6 +3,8 @@ Detect whether or not the user has an ad blocking extension enabled.
 A few ad blockers are not detectable with this approach e.g. Safari / Adblock
 Code inspired by just-detect-adblock's: https://git.io/JgL4L
 */
+/*istanbul ignore file -- adElementBlocked can't be tested without patching each of the properties of
+HTMLElement.prototype that it accesses, defeating the purpose of the test! */
 
 let adBlockInUse: boolean | undefined = undefined;
 
@@ -17,7 +19,6 @@ function adElementBlocked(ad: HTMLElement): boolean {
 		ad.clientWidth === 0
 	)
 		return true;
-
 	const adStyles = window.getComputedStyle(ad);
 
 	if (adStyles.getPropertyValue('display') === 'none') return true;

--- a/src/detectAdBlocker.ts
+++ b/src/detectAdBlocker.ts
@@ -1,0 +1,64 @@
+/**
+Detect whether of not the user has an ad-blocking extension enabled.
+A few ad blockers are not detectable with this approach e.g. Safari / Adblock
+Code inspired by just-detect-adblock's: https://git.io/JgL4L
+*/
+
+let adBlockInUse: boolean | undefined = undefined;
+
+function adElementBlocked(ad: HTMLElement): boolean {
+	if (
+		ad.offsetParent === null ||
+		ad.offsetHeight === 0 ||
+		ad.offsetLeft === 0 ||
+		ad.offsetTop === 0 ||
+		ad.offsetWidth === 0 ||
+		ad.clientHeight === 0 ||
+		ad.clientWidth === 0
+	)
+		return true;
+
+	const adStyles = window.getComputedStyle(ad);
+
+	if (adStyles.getPropertyValue('display') === 'none') return true;
+	if (adStyles.getPropertyValue('visibility') === 'hidden') return true;
+
+	const mozBindingProp = adStyles.getPropertyValue('-moz-binding');
+	if (mozBindingProp.includes('about:')) return true;
+
+	return false;
+}
+
+export function isAdBlockInUse(): Promise<boolean> {
+	if (adBlockInUse !== undefined) {
+		return Promise.resolve(adBlockInUse);
+	}
+
+	if (typeof window.getComputedStyle !== 'function') {
+		// Old browsers not supporting getComputedStyle most likely won't have adBlockers
+		adBlockInUse = false;
+		return Promise.resolve(adBlockInUse);
+	}
+
+	return new Promise((resolve) => {
+		window.requestAnimationFrame(() => {
+			// create a fake ad element and append it to the document
+			const ad = document.createElement('div');
+			ad.setAttribute(
+				'class',
+				'ad_unit pub_300x250 pub_300x250m pub_728x90 text-ad textAd text_ad text_ads text-ads text-ad-links ad-text adSense adBlock adContent adBanner',
+			);
+			ad.setAttribute(
+				'style',
+				'width: 1px !important; height: 1px !important; position: absolute !important; left: -10000px !important; top: -1000px !important;',
+			);
+			document.body.appendChild(ad);
+
+			// avoid a forced layout
+			window.requestAnimationFrame(() => {
+				// if the ad element has been hidden, an ad blocker is enabled.
+				resolve(adElementBlocked(ad));
+			});
+		});
+	});
+}

--- a/src/detectAdBlocker.ts
+++ b/src/detectAdBlocker.ts
@@ -1,5 +1,5 @@
 /**
-Detect whether of not the user has an ad-blocking extension enabled.
+Detect whether or not the user has an ad blocking extension enabled.
 A few ad blockers are not detectable with this approach e.g. Safari / Adblock
 Code inspired by just-detect-adblock's: https://git.io/JgL4L
 */

--- a/src/detectAdBlocker.ts
+++ b/src/detectAdBlocker.ts
@@ -30,6 +30,11 @@ function adElementBlocked(ad: HTMLElement): boolean {
 	return false;
 }
 
+/**
+ * Determines whether or not the user has an ad blocking extension enabled.
+ * Note: positive results can be considered reliable while negative ones may not be.
+ * @returns Promise
+ */
 export function isAdBlockInUse(): Promise<boolean> {
 	if (adBlockInUse !== undefined) {
 		return Promise.resolve(adBlockInUse);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export { sendCommercialMetrics } from './sendCommercialMetrics';
 export type { ThirdPartyTag } from './types';
 export { adSizes } from './ad-sizes';
 export type { SizeKeys, AdSizeString, AdSize } from './ad-sizes';
+export { isAdBlockInUse } from './detectAdBlocker';


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
- Move code implemented in [frontend](https://github.com/guardian/frontend/blob/3e91c6942494aabf089de63000a5eeb81ddf8405/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js#L6) and [dcr](https://github.com/guardian/dotcom-rendering/blob/150fc2d81e6a66d9c3336185e874fc8cd0288546/dotcom-rendering/src/web/lib/detectAdBlocker.ts#L3) so that it can be shared.
- Add to the classes of the fake ad element and conditions under which we consider it to be blocked in order to make function more reliable for certain ad blockers (see [spreadsheet](https://docs.google.com/spreadsheets/d/18n2N5p8ARA4R2ySfe2-bvocCuvJjApdtbMu9fa1Ol8k/edit?usp=sharing)). Code borrowed from [just-detect-adblock](https://github.com/wmcmurray/just-detect-adblock)

## Why?
- Remove duplicated code so that future changes can be made more easily
- Increase accuracy of ad blocker detection
