### PR TITLE
fix: export CustomParams type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,5 @@ export type {
 	AdsConfigBasic,
 	AdsConfigDisabled,
 	AdTargetingBuilder,
+	CustomParams,
 } from './types';


### PR DESCRIPTION
## What does this change?

Add an exported type for `atoms-rendering/YoutubeAtom` 


