### PR TITLE
fix: Export constants from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,3 +25,4 @@ export type {
 	AdTargetingBuilder,
 	CustomParams,
 } from './types';
+export * as constants from './constants';


### PR DESCRIPTION
## What does this change?

Export constants from the package’s `index` file.

## Why?

More consistent usage by consumers.
