### PR TITLE
chore(deps-dev): Use `@types/googletag`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
+# system
+.DS_Store
+
+# Node Modules
 node_modules
+
+# Build
 dist
 coverage
-.DS_Store
+
+# Editor settings
 .idea
+
+# Work-in-progress folder
+wip

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@guardian/prettier": "^0.7",
     "@octokit/core": "^3",
     "@semantic-release/github": "^8",
-    "@types/doubleclick-gpt": "^2019111201.0.0",
+    "@types/googletag": "^1.1.3",
     "@types/google.analytics": "^0.0.42",
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^4.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ specifiers:
   '@guardian/prettier': ^0.7
   '@octokit/core': ^3
   '@semantic-release/github': ^8
-  '@types/doubleclick-gpt': ^2019111201.0.0
   '@types/google.analytics': ^0.0.42
+  '@types/googletag': ^1.1.3
   '@types/jest': ^27.0.2
   '@typescript-eslint/eslint-plugin': ^4.33.0
   '@typescript-eslint/parser': ^4.33.0
@@ -42,8 +42,8 @@ devDependencies:
   '@guardian/prettier': 0.7.0_prettier@2.4.1
   '@octokit/core': 3.5.1
   '@semantic-release/github': 8.0.1_semantic-release@18.0.0
-  '@types/doubleclick-gpt': 2019111201.0.2
   '@types/google.analytics': 0.0.42
+  '@types/googletag': 1.1.4
   '@types/jest': 27.0.2
   '@typescript-eslint/eslint-plugin': 4.33.0_cc617358c89d3f38c52462f6d809db4c
   '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.4.4
@@ -501,6 +501,7 @@ packages:
   /@commitlint/load/14.1.0:
     resolution: {integrity: sha512-p+HbgjhkqLsnxyjOUdEYHztHCp8n2oLVUJTmRPuP5FXLNevh6Gwmxf+NYC2J0sgD084aV2CFi3qu1W4yHWIknA==}
     engines: {node: '>=v12'}
+    requiresBuild: true
     dependencies:
       '@commitlint/execute-rule': 14.0.0
       '@commitlint/resolve-extends': 14.1.0
@@ -1174,12 +1175,12 @@ packages:
       '@babel/types': 7.16.0
     dev: true
 
-  /@types/doubleclick-gpt/2019111201.0.2:
-    resolution: {integrity: sha512-7o6VgAeoziuCDEyv/QWzbIiwJdD07ZdaiJAvxTriHEiaPR9PP1qgHbmBf5e/UTejwTiGGIVkQgfpUO2Enu/Yqw==}
-    dev: true
-
   /@types/google.analytics/0.0.42:
     resolution: {integrity: sha512-w0ZFj3SHznQXSq99kFCuO8tkN6w4T14znjrF2alLCSDnHOXEnpzneyNwxLvekcsDBInr8b5mXmzYh03GArqEyw==}
+    dev: true
+
+  /@types/googletag/1.1.4:
+    resolution: {integrity: sha512-2hUHxgj2xr9JXvAiLL6bZAbc41ZPSLQXIjqhJ3Yuvt2oZEtpXvwdJQDQOJYL3mNwynrsTS4E+m1tZW5mbGSyag==}
     dev: true
 
   /@types/graceful-fs/4.1.5:

--- a/src/global.ts
+++ b/src/global.ts
@@ -18,7 +18,6 @@ declare global {
 			cmd: string;
 			val: Record<string, unknown>;
 		}>;
-		googletag?: googletag.Googletag;
 		guardian: {
 			commercialTimer?: EventTimer;
 			config?: GuardianWindowConfig;

--- a/src/third-party-tags/inizio.ts
+++ b/src/third-party-tags/inizio.ts
@@ -5,11 +5,9 @@ const handleQuerySurveyDone = (
 	survey: { measurementId: string },
 ): void => {
 	if (surveyAvailable) {
-		if (window.googletag) {
-			window.googletag.cmd.push(() => {
-				window.googletag?.pubads().setTargeting('inizio', 't');
-			});
-		}
+		window.googletag.cmd.push(() => {
+			window.googletag.pubads().setTargeting('inizio', 't');
+		});
 		console.log(`surveyAvailable: ${survey.measurementId}`);
 	}
 };

--- a/src/third-party-tags/inizio.ts
+++ b/src/third-party-tags/inizio.ts
@@ -5,9 +5,12 @@ const handleQuerySurveyDone = (
 	survey: { measurementId: string },
 ): void => {
 	if (surveyAvailable) {
-		window.googletag.cmd.push(() => {
-			window.googletag.pubads().setTargeting('inizio', 't');
-		});
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- @types/googletag declares it, but it may be missing
+		if (window.googletag) {
+			window.googletag.cmd.push(() => {
+				window.googletag.pubads().setTargeting('inizio', 't');
+			});
+		}
 		console.log(`surveyAvailable: ${survey.measurementId}`);
 	}
 };

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,5 +7,8 @@
   },
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["**/*.spec.*"]
+  "exclude": [
+	  "**/*.spec.*",
+	  "**/*.test.*",
+	]
 }


### PR DESCRIPTION
## What does this change?

Use `@types/googletag` instead of `@types/doubleclick-gpt`. See guardian/frontend#24349.

## Why?

The types are more restrictive, hence better.