### PR TITLE
fix: Fix @guardian/libs to version 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@commitlint/config-conventional": "^14",
     "@guardian/consent-management-platform": "^8",
     "@guardian/eslint-config-typescript": "^0.7",
-    "@guardian/libs": "^3",
+    "@guardian/libs": "3.3.0",
     "@guardian/prettier": "^0.7",
     "@octokit/core": "^3",
     "@semantic-release/github": "^8",
@@ -78,6 +78,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@guardian/libs": "^3"
+    "@guardian/libs": "^3.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ specifiers:
   '@commitlint/config-conventional': ^14
   '@guardian/consent-management-platform': ^8
   '@guardian/eslint-config-typescript': ^0.7
-  '@guardian/libs': ^3
+  '@guardian/libs': 3.3.0
   '@guardian/prettier': ^0.7
   '@octokit/core': ^3
   '@semantic-release/github': ^8
@@ -38,7 +38,7 @@ devDependencies:
   '@commitlint/config-conventional': 14.1.0
   '@guardian/consent-management-platform': 8.0.1
   '@guardian/eslint-config-typescript': 0.7.0_5dc17954397827e5be42442a8923306d
-  '@guardian/libs': 3.5.0_web-vitals@2.1.2
+  '@guardian/libs': 3.3.0
   '@guardian/prettier': 0.7.0_prettier@2.4.1
   '@octokit/core': 3.5.1
   '@semantic-release/github': 8.0.1_semantic-release@18.0.0
@@ -666,14 +666,6 @@ packages:
 
   /@guardian/libs/3.3.0:
     resolution: {integrity: sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==}
-    dev: true
-
-  /@guardian/libs/3.5.0_web-vitals@2.1.2:
-    resolution: {integrity: sha512-G6n2Flox39condhlALyJ48oMv2kRqbH+1M84SAYNjZZ9oFmpjdDf3mqU7YEX0Cxx5r+89PvUbqEYZLolnMUn2A==}
-    peerDependencies:
-      web-vitals: ^2
-    dependencies:
-      web-vitals: 2.1.2
     dev: true
 
   /@guardian/prettier/0.7.0_prettier@2.4.1:


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

This PR reverses the version bump of [@guardian/libs](https://github.com/guardian/libs) applied in #414. Instead we fix the version to `3.3.0` for both the development and peer dependency.

## Why?

This resolves an an issue caused when using this package as a dependency of Dotcom Rendering. A runtime error occurred when trying to run the DCR server and was of the form `localStorage is not defined`. This appears to be caused by an attempt to use a browser API on the server.

The version can be returned to `^3` when a more suitable fix for the error is found upstream.
