### PR TITLE
feat: Ad Targeting – Content

### DIFF
--- a/src/targeting/content.spec.ts
+++ b/src/targeting/content.spec.ts
@@ -1,0 +1,83 @@
+import type { ContentTargeting } from './content';
+import { getContentTargeting } from './content';
+
+describe('Content Targeting', () => {
+	test('should output the same thing', () => {
+		const content: ContentTargeting = {
+			bl: ['a', 'b'],
+			br: 'f',
+			co: ['Max Duval'],
+			ct: 'article',
+			dcre: 'f',
+			edition: 'uk',
+			k: ['a', 'b'],
+			ob: null,
+			p: 'ng',
+			rp: 'dotcom-platform',
+			s: 'uk-news',
+			se: ['one'],
+			sens: 'f',
+			su: '0',
+			tn: 'something',
+			url: '/some/thing',
+			urlkw: ['a', 'b'],
+			vl: '60',
+		};
+
+		expect(getContentTargeting(content)).toEqual(content);
+	});
+
+	const videoLengths: Array<[number, ContentTargeting['vl']]> = [
+		[10, '30'],
+		[25, '30'],
+		[30, '30'],
+
+		[31, '60'],
+		[59, '60'],
+		[60, '60'],
+
+		[90, '90'],
+		[120, '120'],
+		[150, '150'],
+		[180, '180'],
+		[210, '210'],
+		[240, '240'],
+
+		[300, '300'],
+		[301, '300'],
+		[999, '300'],
+
+		[-999, null],
+		[NaN, null],
+	];
+	test.each(videoLengths)('Video Length (vl) %f => %s', (videoLength, vl) => {
+		const expected: Partial<ContentTargeting> = {
+			vl,
+		};
+
+		const targeting = getContentTargeting(
+			{
+				bl: ['a', 'b'],
+				br: 'f',
+				co: ['Commercial Development'],
+				ct: 'article',
+				dcre: 'f',
+				edition: 'uk',
+				k: ['a', 'b'],
+				ob: null,
+				p: 'ng',
+				rp: 'dotcom-platform',
+				s: 'uk-news',
+				se: ['one'],
+				sens: 'f',
+				su: '0',
+				tn: 'something',
+				url: '/some/thing',
+				urlkw: ['a', 'b'],
+			},
+			videoLength,
+		);
+
+		expect(targeting).toMatchObject(expected);
+	});
+});

--- a/src/targeting/content.spec.ts
+++ b/src/targeting/content.spec.ts
@@ -3,7 +3,7 @@ import { getContentTargeting } from './content';
 
 describe('Content Targeting', () => {
 	test('should output the same thing', () => {
-		const content: ContentTargeting = {
+		const expected: ContentTargeting = {
 			bl: ['a', 'b'],
 			br: 'f',
 			co: ['Max Duval'],
@@ -19,12 +19,33 @@ describe('Content Targeting', () => {
 			sens: 'f',
 			su: '0',
 			tn: 'something',
-			url: '/some/thing',
-			urlkw: ['a', 'b'],
-			vl: '60',
+			url: '/2021/some-thing-or-other',
+			urlkw: ['some', 'thing', 'or', 'other'],
+			vl: null,
 		};
 
-		expect(getContentTargeting(content)).toEqual(content);
+		const targeting = getContentTargeting(
+			{
+				bl: ['a', 'b'],
+				br: 'f',
+				co: ['Max Duval'],
+				ct: 'article',
+				dcre: 'f',
+				edition: 'uk',
+				k: ['a', 'b'],
+				ob: null,
+				p: 'ng',
+				rp: 'dotcom-platform',
+				s: 'uk-news',
+				se: ['one'],
+				sens: 'f',
+				su: '0',
+				tn: 'something',
+			},
+			'/2021/some-thing-or-other',
+		);
+
+		expect(targeting).toEqual(expected);
 	});
 
 	const videoLengths: Array<[number, ContentTargeting['vl']]> = [
@@ -72,9 +93,8 @@ describe('Content Targeting', () => {
 				sens: 'f',
 				su: '0',
 				tn: 'something',
-				url: '/some/thing',
-				urlkw: ['a', 'b'],
 			},
+			'/2021/my-great-blog-post',
 			videoLength,
 		);
 

--- a/src/targeting/content.spec.ts
+++ b/src/targeting/content.spec.ts
@@ -116,7 +116,7 @@ describe('Content Targeting', () => {
 		});
 	});
 
-	describe('Sensitive', () => {
+	describe('Sensitive (sens)', () => {
 		const sensitive: Array<[boolean, ContentTargeting['sens']]> = [
 			[true, 't'],
 			[false, 'f'],
@@ -139,30 +139,7 @@ describe('Content Targeting', () => {
 		});
 	});
 
-	describe('Sensitive', () => {
-		const sensitive: Array<[boolean, ContentTargeting['sens']]> = [
-			[true, 't'],
-			[false, 'f'],
-		];
-
-		test.each(sensitive)('For `%s`, returns `%s`', (sensitive, sens) => {
-			const expected: Pick<ContentTargeting, 'sens'> = {
-				sens,
-			};
-
-			const targeting = getContentTargeting(
-				{
-					...defaultValues,
-					sensitive,
-				},
-				defaultTargeting,
-			);
-
-			expect(targeting).toMatchObject(expected);
-		});
-	});
-
-	describe('Surging', () => {
+	describe('Surging (su)', () => {
 		const sensitive: Array<[number, ContentTargeting['su']]> = [
 			[0, ['0']],
 			[1, ['0']],
@@ -193,6 +170,107 @@ describe('Content Targeting', () => {
 				{
 					...defaultValues,
 					surging,
+				},
+				defaultTargeting,
+			);
+
+			expect(targeting).toMatchObject(expected);
+		});
+	});
+
+	describe('Path and its keywords (url and urlkw)', () => {
+		test('Handles standard slug like /2021/nov/1/my-great-blog-post', () => {
+			const path: ContentTargeting['url'] =
+				'/2021/nov/1/my-great-blog-post';
+			const keywords: ContentTargeting['urlkw'] = [
+				'my',
+				'great',
+				'blog',
+				'post',
+			];
+
+			const expected: Pick<ContentTargeting, 'url' | 'urlkw'> = {
+				url: path,
+				urlkw: keywords,
+			};
+
+			const targeting = getContentTargeting(
+				{
+					...defaultValues,
+					path,
+				},
+				defaultTargeting,
+			);
+
+			expect(targeting).toMatchObject(expected);
+		});
+
+		test('Handles double dashes in slug', () => {
+			const path: ContentTargeting['url'] =
+				'/world/2021/nov/1/one--ring-2---rule-them-all';
+			const keywords: ContentTargeting['urlkw'] = [
+				'one',
+				'ring',
+				'2',
+				'rule',
+				'them',
+				'all',
+			];
+
+			const expected: Pick<ContentTargeting, 'url' | 'urlkw'> = {
+				url: path,
+				urlkw: keywords,
+			};
+
+			const targeting = getContentTargeting(
+				{
+					...defaultValues,
+					path,
+				},
+				defaultTargeting,
+			);
+
+			expect(targeting).toMatchObject(expected);
+		});
+
+		test('Handles no leading slash', () => {
+			const path: ContentTargeting['url'] = '/2021/my-great-blog-post';
+			const keywords: ContentTargeting['urlkw'] = [
+				'my',
+				'great',
+				'blog',
+				'post',
+			];
+
+			const expected: Pick<ContentTargeting, 'url' | 'urlkw'> = {
+				url: path,
+				urlkw: keywords,
+			};
+
+			const targeting = getContentTargeting(
+				{
+					...defaultValues,
+					path,
+				},
+				defaultTargeting,
+			);
+
+			expect(targeting).toMatchObject(expected);
+		});
+
+		test('Handles weird URL ///', () => {
+			const path: ContentTargeting['url'] = '///';
+			const keywords: ContentTargeting['urlkw'] = [];
+
+			const expected: Pick<ContentTargeting, 'url' | 'urlkw'> = {
+				url: path,
+				urlkw: keywords,
+			};
+
+			const targeting = getContentTargeting(
+				{
+					...defaultValues,
+					path,
 				},
 				defaultTargeting,
 			);

--- a/src/targeting/content.spec.ts
+++ b/src/targeting/content.spec.ts
@@ -1,12 +1,36 @@
 import type { ContentTargeting } from './content';
 import { getContentTargeting } from './content';
 
+const defaultParams: Parameters<typeof getContentTargeting> = [
+	{
+		path: '/2021/my-great-blog-post',
+		contributors: ['Commercial Development'],
+		contentType: 'article',
+		platform: 'NextGen',
+		sensitive: false,
+		surging: 50,
+		tones: ['minutebyminute'],
+	},
+	{
+		bl: ['a', 'b'],
+		dcre: 'f',
+		edition: 'uk',
+		k: ['a', 'b'],
+		ob: null,
+		rp: 'dotcom-platform',
+		s: 'uk-news',
+		se: ['one'],
+	},
+];
+
+const [defaultValues, defaultTargeting] = defaultParams;
+
 describe('Content Targeting', () => {
 	test('should output the same thing', () => {
 		const expected: ContentTargeting = {
 			bl: ['a', 'b'],
 			br: 'f',
-			co: ['Max Duval'],
+			co: ['Commercial', 'Comm-Dev'],
 			ct: 'article',
 			dcre: 'f',
 			edition: 'uk',
@@ -17,8 +41,8 @@ describe('Content Targeting', () => {
 			s: 'uk-news',
 			se: ['one'],
 			sens: 'f',
-			su: '0',
-			tn: 'something',
+			su: ['0'],
+			tn: ['news'],
 			url: '/2021/some-thing-or-other',
 			urlkw: ['some', 'thing', 'or', 'other'],
 			vl: null,
@@ -26,78 +50,154 @@ describe('Content Targeting', () => {
 
 		const targeting = getContentTargeting(
 			{
+				path: '/2021/some-thing-or-other',
+				contributors: ['Commercial', 'Comm-Dev'],
+				branding: 'Foundation',
+				contentType: 'article',
+				platform: 'NextGen',
+				sensitive: false,
+				tones: ['news'],
+				surging: 0,
+			},
+			{
 				bl: ['a', 'b'],
-				br: 'f',
-				co: ['Max Duval'],
-				ct: 'article',
 				dcre: 'f',
 				edition: 'uk',
 				k: ['a', 'b'],
 				ob: null,
-				p: 'ng',
 				rp: 'dotcom-platform',
 				s: 'uk-news',
 				se: ['one'],
-				sens: 'f',
-				su: '0',
-				tn: 'something',
 			},
-			'/2021/some-thing-or-other',
 		);
 
 		expect(targeting).toEqual(expected);
 	});
 
-	const videoLengths: Array<[number, ContentTargeting['vl']]> = [
-		[10, '30'],
-		[25, '30'],
-		[30, '30'],
+	describe('Video Length (vl)', () => {
+		const videoLengths: Array<[number, ContentTargeting['vl']]> = [
+			[10, '30'],
+			[25, '30'],
+			[30, '30'],
 
-		[31, '60'],
-		[59, '60'],
-		[60, '60'],
+			[31, '60'],
+			[59, '60'],
+			[60, '60'],
 
-		[90, '90'],
-		[120, '120'],
-		[150, '150'],
-		[180, '180'],
-		[210, '210'],
-		[240, '240'],
+			[90, '90'],
+			[120, '120'],
+			[150, '150'],
+			[180, '180'],
+			[210, '210'],
+			[240, '240'],
 
-		[300, '300'],
-		[301, '300'],
-		[999, '300'],
+			[300, '300'],
+			[301, '300'],
+			[999, '300'],
 
-		[-999, null],
-		[NaN, null],
-	];
-	test.each(videoLengths)('Video Length (vl) %f => %s', (videoLength, vl) => {
-		const expected: Partial<ContentTargeting> = {
-			vl,
-		};
+			[-999, null],
+			[NaN, null],
+		];
 
-		const targeting = getContentTargeting(
-			{
-				bl: ['a', 'b'],
-				br: 'f',
-				co: ['Commercial Development'],
-				ct: 'article',
-				dcre: 'f',
-				edition: 'uk',
-				k: ['a', 'b'],
-				ob: null,
-				p: 'ng',
-				rp: 'dotcom-platform',
-				s: 'uk-news',
-				se: ['one'],
-				sens: 'f',
-				su: '0',
-				tn: 'something',
-			},
-			'/2021/my-great-blog-post',
-			videoLength,
-		);
+		test.each(videoLengths)('For `%f`, returns `%s`', (videoLength, vl) => {
+			const expected: Partial<ContentTargeting> = {
+				vl,
+			};
 
-		expect(targeting).toMatchObject(expected);
+			const targeting = getContentTargeting(
+				{
+					...defaultValues,
+					videoLength,
+				},
+				defaultTargeting,
+			);
+
+			expect(targeting).toMatchObject(expected);
+		});
+	});
+
+	describe('Sensitive', () => {
+		const sensitive: Array<[boolean, ContentTargeting['sens']]> = [
+			[true, 't'],
+			[false, 'f'],
+		];
+
+		test.each(sensitive)('For `%s`, returns `%s`', (sensitive, sens) => {
+			const expected: Pick<ContentTargeting, 'sens'> = {
+				sens,
+			};
+
+			const targeting = getContentTargeting(
+				{
+					...defaultValues,
+					sensitive,
+				},
+				defaultTargeting,
+			);
+
+			expect(targeting).toMatchObject(expected);
+		});
+	});
+
+	describe('Sensitive', () => {
+		const sensitive: Array<[boolean, ContentTargeting['sens']]> = [
+			[true, 't'],
+			[false, 'f'],
+		];
+
+		test.each(sensitive)('For `%s`, returns `%s`', (sensitive, sens) => {
+			const expected: Pick<ContentTargeting, 'sens'> = {
+				sens,
+			};
+
+			const targeting = getContentTargeting(
+				{
+					...defaultValues,
+					sensitive,
+				},
+				defaultTargeting,
+			);
+
+			expect(targeting).toMatchObject(expected);
+		});
+	});
+
+	describe('Surging', () => {
+		const sensitive: Array<[number, ContentTargeting['su']]> = [
+			[0, ['0']],
+			[1, ['0']],
+			[49, ['0']],
+
+			[50, ['5']],
+			[99, ['5']],
+
+			[100, ['5', '4']],
+			[199, ['5', '4']],
+
+			[200, ['5', '4', '3']],
+			[300, ['5', '4', '3', '2']],
+			[400, ['5', '4', '3', '2', '1']],
+
+			[1200, ['5', '4', '3', '2', '1']],
+
+			[NaN, ['0']],
+			[-999, ['0']],
+		];
+
+		test.each(sensitive)('For `%s`, returns `%s`', (surging, su) => {
+			const expected: Pick<ContentTargeting, 'su'> = {
+				su: su.sort(),
+			};
+
+			const targeting = getContentTargeting(
+				{
+					...defaultValues,
+					surging,
+				},
+				defaultTargeting,
+			);
+
+			expect(targeting).toMatchObject(expected);
+		});
 	});
 });

--- a/src/targeting/content.ts
+++ b/src/targeting/content.ts
@@ -114,7 +114,7 @@ export type ContentTargeting = {
 	 *
 	 * Type: _Predefined_
 	 *
-	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=177807
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=11958028
 	 */
 	dcre: True | False;
 

--- a/src/targeting/content.ts
+++ b/src/targeting/content.ts
@@ -1,0 +1,245 @@
+import type { False, True } from '../types';
+
+/* -- Types -- */
+
+const branding = {
+	Foundation: 'f',
+	Paid: 'p',
+	Sponsored: 's',
+} as const;
+
+const editions = {
+	UnitedKingdom: 'uk',
+	UnitedStates: 'us',
+	Australia: 'au',
+	International: 'int',
+} as const;
+
+const videoLengths = [
+	'25', // TODO: confirm this is a real value
+	'30',
+	'60',
+	'90',
+	'120',
+	'150',
+	'180',
+	'210',
+	'240',
+	'270',
+	'300',
+] as const;
+
+const surging = {
+	'Not surging': '0',
+	'50-100 page view per minute': '5',
+	'100+ page view per minute': '4',
+	'200+ page view per minute': '3',
+	'300+ page view per minute': '2',
+	'400+ page view per minute': '1',
+} as const;
+
+const platform = {
+	R2: 'r2',
+	NextGen: 'ng',
+	MobileApp: 'app',
+	AcceleratedMobilePages: 'amp',
+} as const;
+
+const contentType = [
+	'article',
+	'audio',
+	'crossword',
+	'gallery',
+	'interactive',
+	'liveblog',
+	'network-front',
+	'section',
+	'tag',
+	'video',
+] as const;
+
+/**
+ * Content Targeting comes from the server
+ *
+ * For a specific URL, it will only change on
+ * - a Composer/CAPI update
+ * - a rendering platform capability update
+ * - a main media update
+ * - a series tag update
+ * - a surge in page views per minute
+ *
+ */
+export type ContentTargeting = {
+	/**
+	 * **Bl**og tags – [see on Ad Manager][gam]
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=186687
+	 */
+	bl: string[];
+
+	/**
+	 * **Br**anding - [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=259767
+	 */
+	br: typeof branding[keyof typeof branding] | null;
+
+	/**
+	 * **Co**ntributor - [see on Ad Manager][gam]
+	 *
+	 * Array of all contributors to the content on the page
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=186207
+	 */
+	co: string[];
+
+	/**
+	 * **C**ontent **T**ype - [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=177807
+	 */
+	ct: typeof contentType[number];
+
+	/**
+	 * **D**ot**c**om-**r**endering **E**ligible - [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=177807
+	 */
+	dcre: True | False;
+
+	/**
+	 * **Edition** - [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=174207
+	 */
+	edition: typeof editions[keyof typeof editions];
+
+	/**
+	 * **K**eywords - [see on Ad Manager][gam]
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=177687
+	 */
+	k: string[];
+
+	/**
+	 * **Ob**server Content - [see on Ad Manager][gam]
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=256887
+	 */
+	ob: 't' | null;
+
+	/**
+	 * **P**latform - [see on Ad Manager][gam]
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=180207
+	 */
+	p: typeof platform[keyof typeof platform];
+
+	/**
+	 * Rendering Platform - [see on Ad Manager][gam]
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=11881005
+	 */
+	rp: 'dotcom-rendering' | 'dotcom-platform';
+
+	/**
+	 * Site **S**ection - [see on Ad Manager][gam]
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=173967
+	 */
+	s: string;
+
+	/**
+	 * **Se**ries - [see on Ad Manager][gam]
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=180447
+	 */
+	se: string[];
+
+	/**
+	 * **Sens**itive - [see on Ad Manager][gam]
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=11654206
+	 */
+	sens: True | False;
+
+	/**
+	 * **Su**rging Article - [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=185007
+	 */
+	su: typeof surging[keyof typeof surging];
+
+	/**
+	 * **T**o**n**e - [see on Ad Manager][gam]
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=191487
+	 */
+	tn: string;
+
+	/**
+	 * **U**niform **R**esource **L**ocator - [see on Ad Manager][gam]
+	 *
+	 * Relative to `www.theguardian.com`, starts with `/`
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=174327
+	 */
+	url: `/${string}`;
+
+	/**
+	 * URL Keywords - [see on Ad Manager][gam]
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=12058265
+	 */
+	urlkw: string[];
+
+	/**
+	 * **V**ideo **L**ength - [see on Ad Manager][gam]
+	 *
+	 * Video.JS only (?)
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=195087
+	 */
+	vl: null | typeof videoLengths[number];
+};
+
+/* -- Methods -- */
+
+const getVideoLength = (videoLength: number): ContentTargeting['vl'] => {
+	const index = Math.min(Math.ceil(videoLength / 30), 10);
+	return videoLengths[index] ?? null;
+};
+
+/* -- Targeting -- */
+
+export const getContentTargeting = (
+	targeting: Omit<ContentTargeting, 'vl'>,
+	videoLength?: number,
+): ContentTargeting => {
+	return {
+		vl: videoLength ? getVideoLength(videoLength) : null,
+		...targeting,
+	};
+};

--- a/src/targeting/content.ts
+++ b/src/targeting/content.ts
@@ -1,3 +1,4 @@
+import { isString } from '@guardian/libs';
 import type { False, True } from '../types';
 
 /* -- Types -- */
@@ -232,14 +233,26 @@ const getVideoLength = (videoLength: number): ContentTargeting['vl'] => {
 	return videoLengths[index] ?? null;
 };
 
+const getUrlKeywords = (url: ContentTargeting['url']): string[] => {
+	const lastSegment = url
+		.split('/')
+		.filter(Boolean) // This handles a trailing slash
+		.slice(-1)[0];
+
+	return isString(lastSegment) ? lastSegment.split('-') : [];
+};
+
 /* -- Targeting -- */
 
 export const getContentTargeting = (
-	targeting: Omit<ContentTargeting, 'vl'>,
+	targeting: Omit<ContentTargeting, 'vl' | 'url' | 'urlkw'>,
+	url: ContentTargeting['url'],
 	videoLength?: number,
 ): ContentTargeting => {
 	return {
-		vl: videoLength ? getVideoLength(videoLength) : null,
 		...targeting,
+		vl: videoLength ? getVideoLength(videoLength) : null,
+		url,
+		urlkw: getUrlKeywords(url),
 	};
 };

--- a/src/targeting/content.ts
+++ b/src/targeting/content.ts
@@ -239,7 +239,7 @@ const getUrlKeywords = (url: ContentTargeting['url']): string[] => {
 		.filter(Boolean) // This handles a trailing slash
 		.slice(-1)[0];
 
-	return isString(lastSegment) ? lastSegment.split('-') : [];
+	return isString(lastSegment) ? lastSegment.split('-').filter(Boolean) : [];
 };
 
 const getSurgingParam = (surging: number): ContentTargeting['su'] => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,3 +72,8 @@ export type AdsConfigEnabled =
 export type AdsConfig = AdsConfigEnabled | AdsConfigDisabled;
 
 export type AdTargetingBuilder = () => Promise<AdsConfig>;
+
+type True = 't';
+type False = 'f';
+type NotApplicable = 'na';
+export type { True, False, NotApplicable };


### PR DESCRIPTION
## What does this change?

Adds types around Content Targeting, which as per the JSDoc:

```ts
/**
 * Content Targeting comes from the server
 *
 * For a specific URL, it will only change on
 * - a Composer/CAPI update
 * - a rendering platform capability update
 * - a main media update
 * - a series tag update
 * - a surge in page views per minute
 */
export type ContentTargeting = { /* … */ }
```

### `getContentTargeting`

Returns key-value pairs based on CAPI content. Takes an optional `videoLength` parameter.

[Explore the IDE IntelliSense](https://github.dev/guardian/commercial-core/blob/6c10c1ea1624b9e2c9c67dabc3326a849402531b/src/targeting/content.ts)

## Why?

JSDoc style means the documentation is as close as possible to the actual code.