### PR TITLE
feat: Ad Targeting – Personalised

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,5 +7,8 @@
   },
   "extends": ["@guardian/eslint-config-typescript"],
   "globals": { "googletag": "readonly" },
-  "ignorePatterns": ["dist", "coverage", "src/__vendor"]
+  "ignorePatterns": ["dist", "coverage", "src/__vendor"],
+  "rules": {
+	  "no-use-before-define": ["error", { "functions": true, "classes": true }]
+  }
 }

--- a/src/ad-targeting-youtube.ts
+++ b/src/ad-targeting-youtube.ts
@@ -14,6 +14,8 @@ import type {
 
 type CustomParams = Record<string, MaybeArray<string | number | boolean>>;
 
+const disabledAds: AdsConfigDisabled = { disableAds: true };
+
 const buildCustomParamsFromCookies = (): CustomParams =>
 	canUseDom()
 		? {
@@ -74,8 +76,6 @@ const buildAdsConfig = (
 	// Shouldn't happen but handle if no matching framework
 	return disabledAds;
 };
-
-const disabledAds: AdsConfigDisabled = { disableAds: true };
 
 const buildAdsConfigWithConsent = (
 	isAdFreeUser: boolean,

--- a/src/sendCommercialMetrics.ts
+++ b/src/sendCommercialMetrics.ts
@@ -1,14 +1,6 @@
 import { log } from '@guardian/libs';
 import { EventTimer } from './EventTimer';
 
-type CommercialMetrics = {
-	browser_id?: string;
-	page_view_id: string;
-	platform: string;
-	metrics: readonly Metrics[];
-	properties: readonly Properties[];
-};
-
 type Metrics = {
 	name: string;
 	value: number;
@@ -17,6 +9,14 @@ type Metrics = {
 type Properties = {
 	name: string;
 	value: string;
+};
+
+type CommercialMetrics = {
+	browser_id?: string;
+	page_view_id: string;
+	platform: string;
+	metrics: readonly Metrics[];
+	properties: readonly Properties[];
 };
 
 export function sendCommercialMetrics(

--- a/src/targeting/personalised.spec.ts
+++ b/src/targeting/personalised.spec.ts
@@ -1,0 +1,237 @@
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { storage } from '@guardian/libs';
+import type { PersonalisedTargeting } from './personalised';
+import { getPersonalisedTargeting } from './personalised';
+
+const FREQUENCY_KEY = 'gu.alreadyVisited';
+const AMTGRP_STORAGE_KEY = 'gu.adManagerGroup';
+
+describe('Personalised targeting', () => {
+	describe('TCFv2', () => {
+		test('Full consent', () => {
+			const tcfv2WithFullConsent: ConsentState = {
+				tcfv2: {
+					consents: {
+						1: true,
+						2: true,
+					},
+					eventStatus: 'useractioncomplete',
+					vendorConsents: { abc: false },
+					addtlConsent: 'xyz',
+					gdprApplies: true,
+					tcString: 'I<3IAB.tcf.ftw',
+				},
+			};
+
+			storage.local.setRaw(FREQUENCY_KEY, '1');
+
+			const expected: Partial<PersonalisedTargeting> = {
+				pa: 't',
+				consent_tcfv2: 't',
+				rdp: 'na',
+				fr: '1',
+			};
+			const targeting = getPersonalisedTargeting(tcfv2WithFullConsent);
+			expect(targeting).toMatchObject(expected);
+		});
+
+		test('No consent', () => {
+			const tcfv2WithoutConsent: ConsentState = {
+				tcfv2: {
+					consents: {
+						1: false,
+						2: false,
+						3: false,
+					},
+					eventStatus: 'useractioncomplete',
+					vendorConsents: { abc: false },
+					addtlConsent: 'xyz',
+					gdprApplies: true,
+					tcString: 'I<3IAB.tcf.ftw',
+				},
+			};
+
+			const expected: Partial<PersonalisedTargeting> = {
+				pa: 'f',
+				consent_tcfv2: 'f',
+				rdp: 'na',
+				fr: '0',
+			};
+			const targeting = getPersonalisedTargeting(tcfv2WithoutConsent);
+			expect(targeting).toMatchObject(expected);
+		});
+	});
+
+	describe('CCPA', () => {
+		it('Full Consent', () => {
+			const state: ConsentState = {
+				ccpa: { doNotSell: false },
+			};
+
+			storage.local.setRaw(FREQUENCY_KEY, '4');
+
+			const expected: Partial<PersonalisedTargeting> = {
+				pa: 't',
+				consent_tcfv2: 'na',
+				rdp: 'f',
+				fr: '4',
+			};
+			const targeting = getPersonalisedTargeting(state);
+			expect(targeting).toMatchObject(expected);
+		});
+
+		it('Do Not Sell', () => {
+			const state: ConsentState = {
+				ccpa: { doNotSell: true },
+			};
+
+			storage.local.setRaw(FREQUENCY_KEY, '4');
+
+			const expected: Partial<PersonalisedTargeting> = {
+				pa: 'f',
+				consent_tcfv2: 'na',
+				rdp: 't',
+				fr: '0',
+			};
+			const targeting = getPersonalisedTargeting(state);
+			expect(targeting).toMatchObject(expected);
+		});
+	});
+
+	describe('AUS', () => {
+		test('Full Consent', () => {
+			const state: ConsentState = {
+				aus: { personalisedAdvertising: true },
+			};
+
+			storage.local.setRaw(FREQUENCY_KEY, '12');
+
+			const expected: Partial<PersonalisedTargeting> = {
+				pa: 't',
+				consent_tcfv2: 'na',
+				rdp: 'na',
+				fr: '10-15',
+			};
+			const targeting = getPersonalisedTargeting(state);
+			expect(targeting).toMatchObject(expected);
+		});
+
+		test('Personalised Advertising OFF', () => {
+			const state: ConsentState = {
+				aus: { personalisedAdvertising: false },
+			};
+
+			storage.local.setRaw(FREQUENCY_KEY, '12');
+
+			const expected: Partial<PersonalisedTargeting> = {
+				pa: 'f',
+				consent_tcfv2: 'na',
+				rdp: 'na',
+				fr: '0',
+			};
+			const targeting = getPersonalisedTargeting(state);
+			expect(targeting).toMatchObject(expected);
+		});
+	});
+
+	describe('Frequency', () => {
+		const frequencies: Array<[PersonalisedTargeting['fr'], number]> = [
+			['0', 0],
+			['1', 1],
+			['2', 2],
+			['3', 3],
+			['4', 4],
+			['5', 5],
+			['6-9', 6],
+			['6-9', 9],
+			['10-15', 10],
+			['10-15', 13],
+			['10-15', 15],
+			['16-19', 16],
+			['16-19', 18],
+			['16-19', 19],
+			['20-29', 20],
+			['20-29', 25],
+			['20-29', 29],
+			['30plus', 30],
+			['30plus', 99],
+			['30plus', 365],
+			['0', NaN],
+			['0', -666],
+		];
+		test.each(frequencies)('Should get `%s` for %f', (fr, val) => {
+			const state: ConsentState = {
+				ccpa: { doNotSell: false },
+			};
+
+			storage.local.setRaw(FREQUENCY_KEY, String(val));
+
+			const expected: Partial<PersonalisedTargeting> = {
+				pa: 't',
+				consent_tcfv2: 'na',
+				rdp: 'f',
+				fr,
+			};
+			const targeting = getPersonalisedTargeting(state);
+			expect(targeting).toMatchObject(expected);
+		});
+	});
+	describe('Ad Manager Group', () => {
+		const groups: Array<[PersonalisedTargeting['amtgrp'], number]> = [
+			['1', 1 / 12],
+			['2', 2 / 12],
+			['3', 3 / 12],
+			['4', 4 / 12],
+			['5', 5 / 12],
+			['6', 6 / 12],
+			['7', 7 / 12],
+			['8', 8 / 12],
+			['9', 9 / 12],
+			['10', 10 / 12],
+			['11', 11 / 12],
+			['12', 12 / 12],
+			// handle cases where Math.random() is outside the 0-1 range
+			['12', -999],
+			['12', 999],
+		];
+
+		test.each(groups)('Should get `%s` if it exists', (amtgrp, val) => {
+			const state: ConsentState = {
+				ccpa: { doNotSell: false },
+			};
+
+			storage.local.remove(AMTGRP_STORAGE_KEY);
+			const mockRandom = jest
+				.spyOn(Math, 'random')
+				.mockReturnValue(val - 1 / 12 / 2);
+
+			const expected: Partial<PersonalisedTargeting> = {
+				pa: 't',
+				consent_tcfv2: 'na',
+				rdp: 'f',
+				amtgrp,
+			};
+			const targeting = getPersonalisedTargeting(state);
+			expect(targeting).toMatchObject(expected);
+
+			mockRandom.mockRestore();
+		});
+	});
+
+	describe('Unknown', () => {
+		test('Not Applicable', () => {
+			const state: ConsentState = {};
+
+			const expected: PersonalisedTargeting = {
+				amtgrp: null,
+				fr: '0',
+				permutive: [],
+				pa: 'f',
+				consent_tcfv2: 'na',
+				rdp: 'na',
+			};
+			const targeting = getPersonalisedTargeting(state);
+			expect(targeting).toMatchObject(expected);
+		});
+	});
+});

--- a/src/targeting/personalised.ts
+++ b/src/targeting/personalised.ts
@@ -21,7 +21,6 @@ const frequency = [
 	'16-19',
 	'20-29',
 	'30plus',
-	'5plus', // TODO: remove it (?)
 ] as const;
 
 const AMTGRP_STORAGE_KEY = 'gu.adManagerGroup';

--- a/src/targeting/personalised.ts
+++ b/src/targeting/personalised.ts
@@ -137,7 +137,7 @@ const getFrequencyValue = (
 	state: ConsentState,
 ): PersonalisedTargeting['fr'] => {
 	const rawValue = getRawWithConsent('gu.alreadyVisited', state);
-	if (!rawValue) return '0'; // TODO: should we return `null` instead?
+	if (!rawValue) return '0';
 
 	const visitCount: number = parseInt(rawValue, 10);
 

--- a/src/targeting/personalised.ts
+++ b/src/targeting/personalised.ts
@@ -1,0 +1,250 @@
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import type {
+	TCEventStatusCode,
+	TCFv2ConsentList,
+} from '@guardian/consent-management-platform/dist/types/tcfv2';
+import { storage } from '@guardian/libs';
+import { clearPermutiveSegments, getPermutiveSegments } from '../permutive';
+import type { False, NotApplicable, True } from '../types';
+
+/* -- Types -- */
+
+const frequency = [
+	'0',
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6-9',
+	'10-15',
+	'16-19',
+	'20-29',
+	'30plus',
+	'5plus', // TODO: remove it (?)
+] as const;
+
+const AMTGRP_STORAGE_KEY = 'gu.adManagerGroup';
+const adManagerGroups = [
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9',
+	'10',
+	'11',
+	'12',
+] as const;
+type AdManagerGroup = typeof adManagerGroups[number];
+
+export type PersonalisedTargeting = {
+	/**
+	 * **A**d **M**anager **T**argeting **Gr**ou**p** – [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * Sample values:
+	 * -
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=12318099
+	 * */
+	amtgrp: AdManagerGroup | null;
+
+	/**
+	 * Interaction with TCFv2 banner – [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=12083384
+	 */
+	cmp_interaction?: TCEventStatusCode | NotApplicable;
+
+	/**
+	 * **TCFv2 Consent** to [all purposes] – [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [all purposes]: https://vendor-list.consensu.org/v2/vendor-list.json
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=12080297
+	 * */
+	consent_tcfv2: True | False | NotApplicable;
+
+	/**
+	 * **Fr**equency – [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=214647
+	 */
+	fr: typeof frequency[number];
+
+	/**
+	 * **P**ersonalised **A**ds Consent – [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=11701767
+	 */
+	pa: True | False;
+
+	/**
+	 * **Permutive** user segments – [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * Values: 900+ number IDs
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=11958727
+	 */
+	permutive: string[];
+
+	/**
+	 * **R**estrict **D**ata **P**rocessing Flag – [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=11701767
+	 */
+	rdp: True | False | NotApplicable;
+};
+
+/* -- Methods -- */
+
+const getRawWithConsent = (key: string, state: ConsentState): string | null => {
+	if (state.tcfv2) {
+		if (state.tcfv2.consents['1']) return storage.local.getRaw(key);
+	}
+	if (state.ccpa) {
+		if (!state.ccpa.doNotSell) return storage.local.getRaw(key);
+	}
+	if (state.aus) {
+		if (state.aus.personalisedAdvertising) return storage.local.getRaw(key);
+	}
+
+	return null;
+};
+
+const getFrequencyValue = (
+	state: ConsentState,
+): PersonalisedTargeting['fr'] => {
+	const rawValue = getRawWithConsent('gu.alreadyVisited', state);
+	if (!rawValue) return '0'; // TODO: should we return `null` instead?
+
+	const visitCount: number = parseInt(rawValue, 10);
+
+	if (visitCount <= 5) {
+		return frequency[visitCount] ?? '0';
+	} else if (visitCount >= 6 && visitCount <= 9) {
+		return '6-9';
+	} else if (visitCount >= 10 && visitCount <= 15) {
+		return '10-15';
+	} else if (visitCount >= 16 && visitCount <= 19) {
+		return '16-19';
+	} else if (visitCount >= 20 && visitCount <= 29) {
+		return '20-29';
+	} else if (visitCount >= 30) {
+		return '30plus';
+	}
+
+	return '0';
+};
+
+const tcfv2AllPurposesConsented = (consents: TCFv2ConsentList) =>
+	Object.keys(consents).length > 0 && Object.values(consents).every(Boolean);
+
+const personalisedAdvertising = (state: ConsentState): boolean => {
+	if (state.tcfv2) return tcfv2AllPurposesConsented(state.tcfv2.consents);
+	if (state.ccpa) return !state.ccpa.doNotSell;
+	if (state.aus) return state.aus.personalisedAdvertising;
+
+	return false;
+};
+
+type CMPTargeting = Pick<
+	PersonalisedTargeting,
+	'cmp_interaction' | 'pa' | 'consent_tcfv2' | 'rdp'
+>;
+const getCMPTargeting = (state: ConsentState): CMPTargeting => {
+	if (state.tcfv2) {
+		return {
+			cmp_interaction: state.tcfv2.eventStatus,
+			pa: tcfv2AllPurposesConsented(state.tcfv2.consents) ? 't' : 'f',
+			consent_tcfv2: tcfv2AllPurposesConsented(state.tcfv2.consents)
+				? 't'
+				: 'f',
+			rdp: 'na',
+		};
+	}
+
+	if (state.ccpa) {
+		return {
+			consent_tcfv2: 'na',
+			rdp: state.ccpa.doNotSell ? 't' : 'f',
+			pa: state.ccpa.doNotSell ? 'f' : 't',
+		};
+	}
+
+	if (state.aus) {
+		return {
+			consent_tcfv2: 'na',
+			rdp: 'na',
+			pa: state.aus.personalisedAdvertising ? 't' : 'f',
+		};
+	}
+
+	return {
+		cmp_interaction: 'na',
+		consent_tcfv2: 'na',
+		rdp: 'na',
+		pa: 'f',
+	};
+};
+
+const isAdManagerGroup = (s: string | null): s is AdManagerGroup =>
+	adManagerGroups.some((g) => g === s);
+
+const getAdManagerGroup = (
+	state: ConsentState,
+): PersonalisedTargeting['amtgrp'] => {
+	if (!personalisedAdvertising(state)) {
+		storage.local.remove(AMTGRP_STORAGE_KEY);
+		return null;
+	}
+
+	const existingGroup = storage.local.getRaw(AMTGRP_STORAGE_KEY);
+
+	return isAdManagerGroup(existingGroup)
+		? existingGroup
+		: createAdManagerGroup();
+};
+
+const createAdManagerGroup = (): AdManagerGroup => {
+	const index = Math.floor(Math.random() * adManagerGroups.length);
+	const group = adManagerGroups[index] ?? '12';
+	storage.local.setRaw(AMTGRP_STORAGE_KEY, group);
+	return group;
+};
+
+const getPermutiveWithState = (state: ConsentState) => {
+	if (personalisedAdvertising(state)) return getPermutiveSegments();
+
+	clearPermutiveSegments();
+	return [];
+};
+
+/* -- Targeting -- */
+
+const getPersonalisedTargeting = (
+	state: ConsentState,
+): PersonalisedTargeting => ({
+	amtgrp: getAdManagerGroup(state),
+	fr: getFrequencyValue(state),
+	permutive: getPermutiveWithState(state),
+	...getCMPTargeting(state),
+});
+
+export { getPersonalisedTargeting };

--- a/src/targeting/personalised.ts
+++ b/src/targeting/personalised.ts
@@ -41,6 +41,12 @@ const adManagerGroups = [
 ] as const;
 type AdManagerGroup = typeof adManagerGroups[number];
 
+/**
+ * Personalised Targeting requires user consent
+ *
+ * It allows or prevents personalised advertising, restrict data processing
+ * and handles access to cookies and localstorage
+ */
 export type PersonalisedTargeting = {
 	/**
 	 * **A**d **M**anager **T**argeting **Gr**ou**p** – [see on Ad Manager][gam]

--- a/src/targeting/personalised.ts
+++ b/src/targeting/personalised.ts
@@ -213,6 +213,13 @@ const getCMPTargeting = (state: ConsentState): CMPTargeting => {
 const isAdManagerGroup = (s: string | null): s is AdManagerGroup =>
 	adManagerGroups.some((g) => g === s);
 
+const createAdManagerGroup = (): AdManagerGroup => {
+	const index = Math.floor(Math.random() * adManagerGroups.length);
+	const group = adManagerGroups[index] ?? '12';
+	storage.local.setRaw(AMTGRP_STORAGE_KEY, group);
+	return group;
+};
+
 const getAdManagerGroup = (
 	state: ConsentState,
 ): PersonalisedTargeting['amtgrp'] => {
@@ -226,13 +233,6 @@ const getAdManagerGroup = (
 	return isAdManagerGroup(existingGroup)
 		? existingGroup
 		: createAdManagerGroup();
-};
-
-const createAdManagerGroup = (): AdManagerGroup => {
-	const index = Math.floor(Math.random() * adManagerGroups.length);
-	const group = adManagerGroups[index] ?? '12';
-	storage.local.setRaw(AMTGRP_STORAGE_KEY, group);
-	return group;
 };
 
 const getPermutiveWithState = (state: ConsentState) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,6 @@ export type TagAtrribute = {
 	value: string;
 };
 
-export type GetThirdPartyTag = (arg0: { shouldRun: boolean }) => ThirdPartyTag;
-
 export type ThirdPartyTag = {
 	async?: boolean;
 	attrs?: TagAtrribute[];
@@ -17,6 +15,8 @@ export type ThirdPartyTag = {
 	url?: string;
 	useImage?: boolean;
 };
+
+export type GetThirdPartyTag = (arg0: { shouldRun: boolean }) => ThirdPartyTag;
 
 export type GuardianAnalyticsConfig = {
 	trackers: Record<string, string>;


### PR DESCRIPTION
## What does this change?
Adds types around Content Targeting, which as per the JSDoc:

```ts
/**
 * Personalised Targeting requires user consent
 *
 * It allows or prevents personalised advertising, restrict data processing
 * and handles access to cookies and localstorage
 */
export type PersonalisedTargeting = { /* … */ }
```

### `getPersonalisedTargeting`

Returns key-value pairs based on user consent. Will remove existing data in local storage if no consent is given.

[Explore the IDE IntelliSense](https://github.dev/guardian/commercial-core/blob/fc234df1c466f586df6e6f364077bac82903ad74/src/targeting/personalised.ts)

## Why?

JSDoc style means the documentation is as close as possible to the actual code.