### PR TITLE
feat: Ad Targeting – Session

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,14 +43,15 @@
   "devDependencies": {
     "@commitlint/cli": "^13",
     "@commitlint/config-conventional": "^14",
+    "@guardian/ab-core": "^2.0.0",
     "@guardian/consent-management-platform": "^8",
     "@guardian/eslint-config-typescript": "^0.7",
     "@guardian/libs": "3.3.0",
     "@guardian/prettier": "^0.7",
     "@octokit/core": "^3",
     "@semantic-release/github": "^8",
-    "@types/googletag": "^1.1.3",
     "@types/google.analytics": "^0.0.42",
+    "@types/googletag": "^1.1.3",
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
@@ -77,6 +78,7 @@
     "access": "public"
   },
   "peerDependencies": {
+		"@guardian/ab-core": "^2.0.0",
     "@guardian/libs": "^3.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.3
 specifiers:
   '@commitlint/cli': ^13
   '@commitlint/config-conventional': ^14
+  '@guardian/ab-core': ^2.0.0
   '@guardian/consent-management-platform': ^8
   '@guardian/eslint-config-typescript': ^0.7
   '@guardian/libs': 3.3.0
@@ -36,6 +37,7 @@ specifiers:
 devDependencies:
   '@commitlint/cli': 13.2.1
   '@commitlint/config-conventional': 14.1.0
+  '@guardian/ab-core': 2.0.0
   '@guardian/consent-management-platform': 8.0.1
   '@guardian/eslint-config-typescript': 0.7.0_5dc17954397827e5be42442a8923306d
   '@guardian/libs': 3.3.0
@@ -628,6 +630,10 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@guardian/ab-core/2.0.0:
+    resolution: {integrity: sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==}
     dev: true
 
   /@guardian/consent-management-platform/8.0.1:

--- a/src/targeting/session.spec.ts
+++ b/src/targeting/session.spec.ts
@@ -1,0 +1,92 @@
+import type { AllParticipations, SessionTargeting } from './session';
+import { getSessionTargeting } from './session';
+
+describe('Session targeting', () => {
+	test('No participations', () => {
+		const expected: SessionTargeting = {
+			ab: null,
+			at: null,
+			cc: 'GB',
+			pv: '1234567',
+			ref: null,
+			si: 'f',
+		};
+
+		const targeting = getSessionTargeting(
+			{
+				serverSideParticipations: {},
+				clientSideParticipations: {},
+			},
+			{ at: null, pv: '1234567', cc: 'GB', si: 'f' },
+		);
+		expect(targeting).toMatchObject(expected);
+	});
+
+	test('With participations', () => {
+		const participations: AllParticipations = {
+			clientSideParticipations: {
+				'ab-new-ad-targeting': {
+					variant: 'variant',
+				},
+				'ab-some-other-test': {
+					variant: 'notintest',
+				},
+			},
+			serverSideParticipations: {
+				abStandaloneBundle: 'variant',
+			},
+		};
+
+		const expected: SessionTargeting = {
+			ab: ['ab-new-ad-targeting-variant', 'abStandaloneBundle-variant'],
+			at: null,
+			cc: 'GB',
+			pv: '1234567',
+			ref: null,
+			si: 'f',
+		};
+
+		const targeting = getSessionTargeting(participations, {
+			at: null,
+			pv: '1234567',
+			cc: 'GB',
+			si: 'f',
+		});
+		expect(targeting).toMatchObject(expected);
+	});
+
+	const referrers: Array<[SessionTargeting['ref'], `http${string}`]> = [
+		['facebook', 'https://www.facebook.com/index.php'],
+		['google', 'https:///www.google.com/'],
+		['reddit', 'https://www.reddit.com/r/'],
+		['twitter', 'https://t.co/sH0RtUr1'],
+		[null, 'https://example.com/'],
+	];
+
+	test.each(referrers)('should get `%s` for ref: %s', (ref, referrer) => {
+		Object.defineProperty(document, 'referrer', {
+			value: referrer,
+			configurable: true,
+		});
+
+		const expected: SessionTargeting = {
+			ab: null,
+			at: null,
+			cc: 'GB',
+			pv: '1234567',
+			si: 'f',
+			ref,
+		};
+
+		const targeting = getSessionTargeting(
+			{ serverSideParticipations: {}, clientSideParticipations: {} },
+			{
+				at: null,
+				pv: '1234567',
+				cc: 'GB',
+				si: 'f',
+			},
+		);
+		expect(targeting).toMatchObject(expected);
+	});
+});

--- a/src/targeting/session.spec.ts
+++ b/src/targeting/session.spec.ts
@@ -13,6 +13,7 @@ describe('Session targeting', () => {
 		};
 
 		const targeting = getSessionTargeting(
+			'',
 			{
 				serverSideParticipations: {},
 				clientSideParticipations: {},
@@ -46,7 +47,7 @@ describe('Session targeting', () => {
 			si: 'f',
 		};
 
-		const targeting = getSessionTargeting(participations, {
+		const targeting = getSessionTargeting('', participations, {
 			at: null,
 			pv: '1234567',
 			cc: 'GB',
@@ -64,11 +65,6 @@ describe('Session targeting', () => {
 	];
 
 	test.each(referrers)('should get `%s` for ref: %s', (ref, referrer) => {
-		Object.defineProperty(document, 'referrer', {
-			value: referrer,
-			configurable: true,
-		});
-
 		const expected: SessionTargeting = {
 			ab: null,
 			at: null,
@@ -79,6 +75,7 @@ describe('Session targeting', () => {
 		};
 
 		const targeting = getSessionTargeting(
+			referrer,
 			{ serverSideParticipations: {}, clientSideParticipations: {} },
 			{
 				at: null,

--- a/src/targeting/session.ts
+++ b/src/targeting/session.ts
@@ -8,7 +8,7 @@ import type { False, True } from '../types';
 const referrers = ['facebook', 'twitter', 'reddit', 'google'] as const;
 
 /**
- * #### Targeting on browser session
+ * Session Targeting is based on the browser session
  *
  * Includes information such as the country of origin, referrer, page view ID.
  *

--- a/src/targeting/session.ts
+++ b/src/targeting/session.ts
@@ -5,7 +5,24 @@ import type { False, True } from '../types';
 
 /* -- Types -- */
 
-const referrers = ['facebook', 'twitter', 'reddit', 'google'] as const;
+const referrers = [
+	{
+		id: 'facebook',
+		match: 'facebook.com',
+	},
+	{
+		id: 'google',
+		match: 'www.google',
+	},
+	{
+		id: 'twitter',
+		match: '/t.co/',
+	},
+	{
+		id: 'reddit',
+		match: 'reddit.com',
+	},
+] as const;
 
 /**
  * Session Targeting is based on the browser session
@@ -77,7 +94,7 @@ export type SessionTargeting = {
 	 *
 	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=228567
 	 */
-	ref: typeof referrers[number] | null;
+	ref: typeof referrers[number]['id'] | null;
 
 	/**
 	 * **S**igned **I**n – [see on Ad Manager][gam]
@@ -101,32 +118,8 @@ const getReferrer = (): SessionTargeting['ref'] => {
 
 	if (referrer === '') return null;
 
-	type MatchType = {
-		id: typeof referrers[number];
-		match: string;
-	};
-
-	const referrerTypes: MatchType[] = [
-		{
-			id: 'facebook',
-			match: 'facebook.com',
-		},
-		{
-			id: 'google',
-			match: 'www.google',
-		},
-		{
-			id: 'twitter',
-			match: '/t.co/',
-		},
-		{
-			id: 'reddit',
-			match: 'reddit.com',
-		},
-	];
-
-	const matchedRef: MatchType | null =
-		referrerTypes.find((referrerType) =>
+	const matchedRef: typeof referrers[number] | null =
+		referrers.find((referrerType) =>
 			referrer.includes(referrerType.match),
 		) ?? null;
 

--- a/src/targeting/session.ts
+++ b/src/targeting/session.ts
@@ -1,0 +1,173 @@
+import type { Participations } from '@guardian/ab-core';
+import type { CountryCode } from '@guardian/libs';
+import { isString } from '@guardian/libs';
+import type { False, True } from '../types';
+
+/* -- Types -- */
+
+const referrers = ['facebook', 'twitter', 'reddit', 'google'] as const;
+
+/**
+ * #### Targeting on browser session
+ *
+ * Includes information such as the country of origin, referrer, page view ID.
+ *
+ * These values identify a browser session are either generated client-side,
+ * read from a cookie or passed down from the server.
+ */
+export type SessionTargeting = {
+	/**
+	 * **AB** Tests – [see on Ad Manager][gam]
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * Values: typically start with `ab`
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=186327
+	 */
+	ab: string[] | null;
+
+	/**
+	 * **A**d **T**est – [see on Ad Manager][gam]
+	 *
+	 * Used for testing purposes, based on query param and/or cookie.
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * [See Current values](https://frontend.gutools.co.uk/commercial/adtests)
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=177567
+	 */
+	at: string | null;
+
+	/**
+	 * **C**ountry **C**ode – [see on Ad Manager][gam]
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=11703293
+	 */
+	cc: CountryCode;
+
+	/**
+	 * Ophan **P**age **V**iew id – [see on Ad Manager][gam]
+	 *
+	 * ID Generated client-side, usually available on
+	 * `guardian.config.ophan.pageViewId`
+	 *
+	 * Used mainly for internal reporting
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=206127
+	 */
+	pv: string;
+
+	/**
+	 * **Ref**errer – [see on Ad Manager][gam]
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * Sample values:
+	 * - `facebook`
+	 * - `google`
+	 * - `googleplus`
+	 * - `reddit`
+	 * - `twitter`
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=228567
+	 */
+	ref: typeof referrers[number] | null;
+
+	/**
+	 * **S**igned **I**n – [see on Ad Manager][gam]
+	 *
+	 *Whether a user is signed in. Based on presence of a cookie.
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=215727
+	 */
+	si: True | False;
+};
+
+export type AllParticipations = {
+	clientSideParticipations: Participations;
+	serverSideParticipations: Record<string, 'control' | 'variant'>;
+};
+
+/* -- Methods -- */
+
+const getReferrer = (): SessionTargeting['ref'] => {
+	const { referrer } = document;
+
+	if (referrer === '') return null;
+
+	type MatchType = {
+		id: typeof referrers[number];
+		match: string;
+	};
+
+	const referrerTypes: MatchType[] = [
+		{
+			id: 'facebook',
+			match: 'facebook.com',
+		},
+		{
+			id: 'google',
+			match: 'www.google',
+		},
+		{
+			id: 'twitter',
+			match: '/t.co/',
+		},
+		{
+			id: 'reddit',
+			match: 'reddit.com',
+		},
+	];
+
+	const matchedRef: MatchType | null =
+		referrerTypes.find((referrerType) =>
+			referrer.includes(referrerType.match),
+		) ?? null;
+
+	return matchedRef ? matchedRef.id : null;
+};
+
+const experimentsTargeting = ({
+	clientSideParticipations,
+	serverSideParticipations,
+}: AllParticipations): SessionTargeting['ab'] => {
+	const testToParams = (testName: string, variant: string): string | null => {
+		if (variant === 'notintest') return null;
+
+		// GAM key-value pairs accept value strings up to 40 characters long
+		return `${testName}-${variant}`.substring(0, 40);
+	};
+
+	const clientSideExperiment = Object.entries(clientSideParticipations)
+		.map((test) => {
+			const [name, variant] = test;
+			return testToParams(name, variant.variant);
+		})
+		.filter(isString);
+
+	const serverSideExperiments = Object.entries(serverSideParticipations)
+		.map((test) => testToParams(...test))
+		.filter(isString);
+
+	if (clientSideExperiment.length + serverSideExperiments.length === 0)
+		return null;
+
+	return [...clientSideExperiment, ...serverSideExperiments];
+};
+
+/* -- Targeting -- */
+
+export const getSessionTargeting = (
+	participations: AllParticipations,
+	targeting: Omit<SessionTargeting, 'ab' | 'ref'>,
+): SessionTargeting => ({
+	ref: getReferrer(),
+	ab: experimentsTargeting(participations),
+	...targeting,
+});

--- a/src/targeting/session.ts
+++ b/src/targeting/session.ts
@@ -113,9 +113,7 @@ export type AllParticipations = {
 
 /* -- Methods -- */
 
-const getReferrer = (): SessionTargeting['ref'] => {
-	const { referrer } = document;
-
+const getReferrer = (referrer: string): SessionTargeting['ref'] => {
 	if (referrer === '') return null;
 
 	const matchedRef: typeof referrers[number] | null =
@@ -157,10 +155,11 @@ const experimentsTargeting = ({
 /* -- Targeting -- */
 
 export const getSessionTargeting = (
+	referrer: string,
 	participations: AllParticipations,
 	targeting: Omit<SessionTargeting, 'ab' | 'ref'>,
 ): SessionTargeting => ({
-	ref: getReferrer(),
+	ref: getReferrer(referrer),
 	ab: experimentsTargeting(participations),
 	...targeting,
 });


### PR DESCRIPTION
## What does this change?
Adds types around Sessions Targeting, which as per the JSDoc:

```ts
/**
 * Session Targeting is based on the browser session
 *
 * Includes information such as the country of origin, referrer, page view ID.
 *
 * These values identify a browser session are either generated client-side,
 * read from a cookie or passed down from the server.
 */
export type SessionTargeting = { /* … */ }
```

### `getSessionTargeting`

Returns key-value pairs based on the browser session. Requires an object containing server-side and client-side A/B test participations.

[Explore the IDE IntelliSense](https://github.dev/guardian/commercial-core/blob/9023662/src/targeting/session.ts)

## Why?

JSDoc style means the documentation is as close as possible to the actual code.