### PR TITLE
feat: Ad Targeting – Viewport

### DIFF
--- a/src/targeting/viewport.spec.ts
+++ b/src/targeting/viewport.spec.ts
@@ -1,0 +1,64 @@
+import type { ViewportTargeting } from './viewport';
+import { getViewportTargeting } from './viewport';
+
+describe('Viewport targeting', () => {
+	test('No CMP banner will show', () => {
+		const expected: ViewportTargeting = {
+			bp: 'desktop',
+			inskin: 't',
+			skinsize: 's',
+		};
+		const targeting = getViewportTargeting(false);
+		expect(targeting).toMatchObject(expected);
+	});
+
+	test('No CMP will show', () => {
+		const expected: ViewportTargeting = {
+			bp: 'desktop',
+			inskin: 'f',
+			skinsize: 's',
+		};
+		const targeting = getViewportTargeting(true);
+		expect(targeting).toMatchObject(expected);
+	});
+
+	const windowWidths: Array<
+		[number, ViewportTargeting['bp'], ViewportTargeting['skinsize']]
+	> = [
+		[320, 'mobile', 's'],
+		[640, 'mobile', 's'],
+		[739, 'mobile', 's'],
+
+		[750, 'tablet', 's'],
+		[960, 'tablet', 's'],
+
+		[1024, 'desktop', 's'],
+		[1280, 'desktop', 's'],
+		[1440, 'desktop', 's'],
+		[1559, 'desktop', 's'],
+
+		[1560, 'desktop', 'l'],
+		[1680, 'desktop', 'l'],
+		[1920, 'desktop', 'l'],
+		[2560, 'desktop', 'l'],
+	];
+
+	test.each(windowWidths)(
+		'Screen size %f => bp:%s, skinsize:%s',
+		(windowWidth, bp, skinsize) => {
+			const expected: ViewportTargeting = {
+				inskin: 't',
+				bp,
+				skinsize,
+			};
+
+			Object.defineProperty(window, 'innerWidth', {
+				value: windowWidth,
+				configurable: true,
+			});
+
+			const targeting = getViewportTargeting(false);
+			expect(targeting).toMatchObject(expected);
+		},
+	);
+});

--- a/src/targeting/viewport.ts
+++ b/src/targeting/viewport.ts
@@ -1,0 +1,71 @@
+import type { False, True } from '../types';
+
+/* -- Types -- */
+
+/**
+ * Viewport Targeting
+ *
+ * Includes values related to the viewport:
+ * - breakpoint (deprecated?)
+ * - whether a CMP banner will show
+ * - size of page skin
+ */
+export type ViewportTargeting = {
+	/**
+	 * **B**reak**p**oint – [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * TODO: remove 'wide'
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=180327
+	 */
+	bp: 'mobile' | 'tablet' | 'desktop';
+
+	/**
+	 * InSkin (CMP Banner shown) – [see on Ad Manager][gam]
+	 *
+	 * Australia-specific (via Bonzai?)
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=11916570
+	 * */
+	inskin: True | False;
+
+	/**
+	 * **Skin size** – [see on Ad Manager][gam]
+	 *
+	 * Large or Small. Used for InSkin page skins
+	 *
+	 * Type: _Predefined_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=12312030
+	 */
+	skinsize: 'l' | 's';
+};
+
+/* -- Methods -- */
+
+const findBreakpoint = (width: number): ViewportTargeting['bp'] => {
+	if (width >= 980) return 'desktop';
+	if (width >= 740) return 'tablet';
+	return 'mobile';
+};
+
+/* -- Targeting -- */
+
+export const getViewportTargeting = (
+	cmpBannerWillShow: boolean,
+): ViewportTargeting => {
+	const width = window.innerWidth;
+
+	// Don’t show inskin if if a privacy message will be shown
+	const inskin = cmpBannerWillShow ? 'f' : 't';
+
+	return {
+		bp: findBreakpoint(width),
+		skinsize: width >= 1560 ? 'l' : 's',
+		inskin,
+	};
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,3 +72,8 @@ export type AdsConfigEnabled =
 export type AdsConfig = AdsConfigEnabled | AdsConfigDisabled;
 
 export type AdTargetingBuilder = () => Promise<AdsConfig>;
+
+type True = 't';
+type False = 'f';
+type NotApplicable = 'na';
+export type { True, False, NotApplicable };


### PR DESCRIPTION

## What does this change?

Adds types around Content Targeting, which as per the JSDoc:

```ts
/**
 * Viewport Targeting
 *
 * Includes values related to the viewport:
 * - breakpoint (deprecated?)
 * - whether a CMP banner will show
 * - size of page skin
 */
export type ViewportTargeting = { /* … */ }
```

### `getViewportTargeting`

Returns key-value pairs based on the size of the viewport and whether a privacy banner will show.

[Explore the IDE IntelliSense](https://github.dev/guardian/commercial-core/blob/621d956e27fcdfbeed9b9f8b2ca43da75c69d2da/src/targeting/viewport.ts)

## Why?

JSDoc style means the documentation is as close as possible to the actual code.