### PR TITLE
feat: Ad Targeting – Unsure

### DIFF
--- a/src/targeting/unsure.spec.ts
+++ b/src/targeting/unsure.spec.ts
@@ -1,0 +1,16 @@
+import type { UnsureTargeting } from './unsure';
+import { getUnsureTargeting } from './unsure';
+
+describe('Unsure targeting', () => {
+	test('These should never really be used anyways', () => {
+		const unsure: UnsureTargeting = {
+			gdncrm: ['a', 'b', 'c'],
+			ms: 'something',
+			slot: 'top-above-nav',
+			x: 'Krux-ID',
+		};
+
+		const targeting = getUnsureTargeting(unsure);
+		expect(targeting).toMatchObject(unsure);
+	});
+});

--- a/src/targeting/unsure.spec.ts
+++ b/src/targeting/unsure.spec.ts
@@ -7,7 +7,6 @@ describe('Unsure targeting', () => {
 			gdncrm: ['a', 'b', 'c'],
 			ms: 'something',
 			slot: 'top-above-nav',
-			x: 'Krux-ID',
 		};
 
 		const targeting = getUnsureTargeting(unsure);

--- a/src/targeting/unsure.ts
+++ b/src/targeting/unsure.ts
@@ -1,5 +1,8 @@
 /* -- Types -- */
 
+/**
+ * I think all of these are deprecated?!?
+ */
 export type UnsureTargeting = {
 	/**
 	 * **G**uar**d**ia**n** **C**ustomer **R**elation **M**anagement – [see on Ad Manager][gam]
@@ -11,6 +14,8 @@ export type UnsureTargeting = {
 	 * - `"PXHCI2"`
 	 *
 	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=184047
+	 *
+	 * @deprecated (?)
 	 */
 	gdncrm: string | string[];
 
@@ -25,6 +30,8 @@ export type UnsureTargeting = {
 	 * - `"a-rational-fear"`
 	 *
 	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=186807
+	 *
+	 * @deprecated - We no longer use Video.js (?)
 	 */
 	ms: string;
 

--- a/src/targeting/unsure.ts
+++ b/src/targeting/unsure.ts
@@ -1,0 +1,60 @@
+/* -- Types -- */
+
+export type UnsureTargeting = {
+	/**
+	 * **G**uar**d**ia**n** **C**ustomer **R**elation **M**anagement – [see on Ad Manager][gam]
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * Sample values:
+	 * - `"PXPE"`
+	 * - `"PXHCI2"`
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=184047
+	 */
+	gdncrm: string | string[];
+
+	/**
+	 * **M**edia **S**ource – [see on Ad Manager][gam]
+	 *
+	 * Type: _Dynamic_
+	 *
+	 * Sample values:
+	 * - `"epictv"`
+	 * - `"crane.tv"`
+	 * - `"a-rational-fear"`
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=186807
+	 */
+	ms: string;
+
+	/**
+	 * Ad **Slot** ID – [see on Ad Manager][gam]
+	 *
+	 * Type: _Predefined_
+	 *
+	 * Sample values: 'top-above-nav', 'inline-1'
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=174447
+	 */
+	slot: string; // TODO: Narrow to known IDs
+
+	/**
+	 * Kru**x** user segments – [see on Ad Manager][gam]
+	 *
+	 * * Type: _Dynamic_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=200247
+	 *
+	 * @deprecated We no longer use Krux
+	 */
+	x: string;
+};
+
+/* -- Methods -- */
+
+/* -- Targeting -- */
+
+export const getUnsureTargeting = (
+	targeting: UnsureTargeting,
+): UnsureTargeting => targeting;

--- a/src/targeting/unsure.ts
+++ b/src/targeting/unsure.ts
@@ -45,17 +45,6 @@ export type UnsureTargeting = {
 	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=174447
 	 */
 	slot: string; // TODO: Narrow to known IDs
-
-	/**
-	 * Kru**x** user segments – [see on Ad Manager][gam]
-	 *
-	 * * Type: _Dynamic_
-	 *
-	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=200247
-	 *
-	 * @deprecated We no longer use Krux
-	 */
-	x: string;
 };
 
 /* -- Methods -- */


### PR DESCRIPTION
## What does this change?
Adds types around Targeting which we’re not sure about, which as per the JSDoc:

```ts
/**
 * I think all of these are deprecated?!?
 */
export type UnsureTargeting = { /* … */ }
```

### `getUnsureTargeting`

You get back what you pass to it, but I think it should all go, go, go away!

## Why?

JSDoc style means the documentation is as close as possible to the actual code.