### PR TITLE
fix: allow installation in non-pnpm packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # system
 .DS_Store
 
-# Node Modules
+# Node Modules & other Package Managers
 node_modules
+yarn.lock
+package-lock.json
 
 # Build
 dist

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "compile:common": "tsc --project ./tsconfig.build.json --outDir ./dist/cjs --module CommonJS",
     "compile:esm": "tsc --project ./tsconfig.build.json --outDir ./dist/esm",
     "lint": "eslint .",
-    "preinstall": "npx only-allow pnpm",
     "precommit:lint": "lint-staged",
     "prepush:test": "jest --verbose --runInBand --onlyChanged",
     "test": "jest",


### PR DESCRIPTION
## What does this change?

Removes a pre-install step introduced in #404.

## Why?

It cannot be installed in `yarn` and `npm` packages.