### PR TITLE
feat: `EventTimer.mark` and `.trackInGA` are private methods

### DIFF
--- a/src/EventTimer.spec.ts
+++ b/src/EventTimer.spec.ts
@@ -98,7 +98,7 @@ describe('EventTimer', () => {
 			writable: true,
 		});
 		const eventTimer = EventTimer.get();
-		eventTimer.mark(MARK_NAME);
+		eventTimer.trigger(MARK_NAME);
 		expect(eventTimer.events).toHaveLength(3);
 		expect(eventTimer.events.map((event) => event.name).sort()).toEqual(
 			[CMP_INIT, CMP_GOT_CONSENT, MARK_NAME].sort(),
@@ -107,13 +107,13 @@ describe('EventTimer', () => {
 
 	it('mark produces correct event', () => {
 		const eventTimer = EventTimer.get();
-		eventTimer.mark(MARK_NAME);
+		eventTimer.trigger(MARK_NAME);
 		expect(eventTimer.events).toHaveLength(1);
 		expect(eventTimer.events[0]?.name).toBe('mark_name');
 		expect(eventTimer.events[0]?.ts).toBe(1);
 	});
 
-	it('calling mark with performance undefined produces no events', () => {
+	it('calling trigger with performance undefined produces no events', () => {
 		Object.defineProperty(window, 'performance', {
 			configurable: true,
 			enumerable: true,
@@ -121,11 +121,11 @@ describe('EventTimer', () => {
 			writable: true,
 		});
 		const eventTimer = EventTimer.get();
-		eventTimer.mark(MARK_NAME);
+		eventTimer.trigger(MARK_NAME);
 		expect(eventTimer.events).toEqual([]);
 	});
 
-	it('when retrieved mark is undefined produce no events', () => {
+	it('when retrieved and mark is undefined produce no events', () => {
 		const performance = {
 			now: jest.fn(),
 			mark: jest.fn(),
@@ -138,7 +138,7 @@ describe('EventTimer', () => {
 			writable: true,
 		});
 		const eventTimer = EventTimer.get();
-		eventTimer.mark(MARK_NAME);
+		eventTimer.trigger(MARK_NAME);
 		expect(eventTimer.events).toEqual([]);
 	});
 
@@ -156,7 +156,7 @@ describe('EventTimer', () => {
 		);
 	});
 
-	it('triggering two slotReady events causes one mark and one track', () => {
+	it('triggering two slotReady events causes one trigger and one track', () => {
 		const eventTimer = EventTimer.get();
 		eventTimer.trigger('slotReady', 'inline1');
 		eventTimer.trigger('slotReady', 'inline1');

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -168,7 +168,7 @@ export class EventTimer {
 				: {};
 	}
 
-	mark(name: string): void {
+	private mark(name: string): void {
 		const longName = `gu.commercial.${name}`;
 		if (
 			typeof window.performance !== 'undefined' &&

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -168,23 +168,6 @@ export class EventTimer {
 				: {};
 	}
 
-	private mark(name: string): void {
-		const longName = `gu.commercial.${name}`;
-		if (
-			typeof window.performance !== 'undefined' &&
-			'mark' in window.performance
-		) {
-			window.performance.mark(longName);
-			// Most recent mark with this name is the event we just created.
-			const mark = window.performance
-				.getEntriesByName(longName, 'mark')
-				.slice(-1)[0];
-			if (typeof mark !== 'undefined') {
-				this._events.push(new Event(name, mark));
-			}
-		}
-	}
-
 	/**
 	 * Creates a new performance mark
 	 * For slot events also ensures each TYPE of event event is marked only once for 'first'
@@ -224,6 +207,23 @@ export class EventTimer {
 				this.triggers[TRACKED_SLOT_NAME][
 					eventName as keyof SlotEventStatus
 				] = true;
+			}
+		}
+	}
+
+	private mark(name: string): void {
+		const longName = `gu.commercial.${name}`;
+		if (
+			typeof window.performance !== 'undefined' &&
+			'mark' in window.performance
+		) {
+			window.performance.mark(longName);
+			// Most recent mark with this name is the event we just created.
+			const mark = window.performance
+				.getEntriesByName(longName, 'mark')
+				.slice(-1)[0];
+			if (typeof mark !== 'undefined') {
+				this._events.push(new Event(name, mark));
 			}
 		}
 	}

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -228,7 +228,7 @@ export class EventTimer {
 		}
 	}
 
-	trackInGA(eventName: string, label = ''): void {
+	private trackInGA(eventName: string, label = ''): void {
 		const gaEvent = this.gaConfig.logEvents.find(
 			(e) => e.timingVariable === eventName,
 		);


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Makes `trigger` and `trackInGA` private methods of `EventTimer`
Note: contrary to the PR title, this isn't a really feature but needs to be labeled as such in order to trigger a minor release when merged.

## Why?
- Consumers should use `EventTimer.trigger` rather than `.mark` so that we 
   -  track events with Google Analytics
   - de-dup events (?)

We can enforce the use of `trigger` by making the other two methods private.
