### PR TITLE
fix(types): Pick targeting keys + use `type-fest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "prettier": "^2.5.0",
     "semantic-release": "^18.0.1",
     "ts-jest": "^27.0.7",
+    "type-fest": "^2.8.0",
     "typescript": "^4.5.2",
     "web-vitals": "^2.1.2"
   },

--- a/src/targeting/pick-targeting-values.spec.ts
+++ b/src/targeting/pick-targeting-values.spec.ts
@@ -34,36 +34,98 @@ describe('Pick defined values from an object', () => {
 			}),
 		).toEqual({});
 	});
-	test('TypeScript validates output', () => {
+
+	test('The function handles string', () => {
 		const maybeTargeting = {
 			string: 'one',
-			strings: ['two', 'three'],
-			undefined: undefined,
-			emptyString: '',
-			emptyArray: [],
-			arrayOfEmptyString: [''],
-			arrayOfEmptyStrings: ['', '', ''],
 		} as const;
 
 		const targeting = pickTargetingValues(maybeTargeting);
 
 		expect(targeting.string).toEqual(maybeTargeting.string);
+	});
+
+	test('The function handles array of strings', () => {
+		const maybeTargeting = {
+			strings: ['two', 'three'],
+		} as const;
+
+		const targeting = pickTargetingValues(maybeTargeting);
+
 		expect(targeting.strings).toEqual(maybeTargeting.strings);
+	});
+
+	test('The function handles array of empty strings (no type safety)', () => {
+		const maybeTargeting = {
+			arrayOfEmptyStrings: ['', '', ''],
+		} as const;
+
+		const targeting = pickTargetingValues(maybeTargeting);
+
+		expect(targeting.arrayOfEmptyStrings).toBeUndefined();
+	});
+
+	test('The function handles an array of mixed strings', () => {
+		const maybeTargeting = {
+			arrayOfMixedStrings: ['', 'valid', ''],
+		} as const;
+
+		const targeting = pickTargetingValues(maybeTargeting);
+
+		expect(targeting.arrayOfMixedStrings).toEqual(['valid']);
+	});
+
+	test('TypeScript validates the output: undefined is gone', () => {
+		const maybeTargeting = {
+			undefined: undefined,
+		} as const;
+
+		const targeting = pickTargetingValues(maybeTargeting);
+
 		// @ts-expect-error -- this is what we’re checking
 		expect(targeting.undefined).toBeUndefined();
-		// @ts-expect-error -- this is what we’re checking
-		expect(targeting.null).toBeUndefined();
-		// @ts-expect-error -- this is what we’re checking
-		expect(targeting.true).toBeUndefined();
-		// @ts-expect-error -- this is what we’re checking
-		expect(targeting.false).toBeUndefined();
+	});
+
+	test('TypeScript validates the output: emptyString is gone', () => {
+		const maybeTargeting = {
+			emptyString: '',
+		} as const;
+
+		const targeting = pickTargetingValues(maybeTargeting);
+
 		// @ts-expect-error -- this is what we’re checking
 		expect(targeting.emptyString).toBeUndefined();
+	});
+
+	test('TypeScript validates the output: emptyArray is gone', () => {
+		const maybeTargeting = {
+			emptyArray: [],
+		} as const;
+
+		const targeting = pickTargetingValues(maybeTargeting);
+
 		// @ts-expect-error -- this is what we’re checking
 		expect(targeting.emptyArray).toBeUndefined();
+	});
+
+	test('TypeScript validates the output: arrayOfEmptyString is gone', () => {
+		const maybeTargeting = {
+			arrayOfEmptyString: [''],
+		} as const;
+
+		const targeting = pickTargetingValues(maybeTargeting);
+
 		// @ts-expect-error -- this is what we’re checking
 		expect(targeting.arrayOfEmptyString).toBeUndefined();
-		expect(targeting.arrayOfEmptyStrings).toBeUndefined();
+	});
+
+	test('TypeScript validates the output: arrayOfEmptyStrings is gone', () => {
+		const maybeTargeting = {
+			arrayOfEmptyStrings: ['', '', ''],
+		} as const;
+
+		const targeting = pickTargetingValues(maybeTargeting);
+
 		// @ts-expect-error -- this is what we’re checking
 		expect(targeting.arrayOfNonStrings).toBeUndefined();
 	});

--- a/src/targeting/pick-targeting-values.ts
+++ b/src/targeting/pick-targeting-values.ts
@@ -1,18 +1,10 @@
 import { isString } from '@guardian/libs';
+import type { ConditionalExcept } from 'type-fest';
 
-type ValidTargeting<T, K> = '' extends T
-	? never
-	: [] extends T
-	? never
-	: [''] extends T
-	? never
-	: T extends boolean
-	? never
-	: T extends NonNullable<T>
-	? K
-	: never;
-type DefinedKeys<T> = { [K in keyof T]-?: ValidTargeting<T[K], K> }[keyof T];
-type ObjectWithDefinedValues<T> = Pick<T, DefinedKeys<T>>;
+type ValidTargetingObject<Base> = ConditionalExcept<
+	Base,
+	null | undefined | '' | readonly [] | readonly [''] | boolean | number
+>;
 
 const isTargetingString = (string: unknown): boolean =>
 	isString(string) && string !== '';
@@ -51,9 +43,9 @@ export const pickTargetingValues = <
 	T extends Record<string, string | Readonly<string[]> | undefined>,
 >(
 	obj: T,
-): ObjectWithDefinedValues<T> => {
-	const initialValue = {} as ObjectWithDefinedValues<T>;
-	return Object.entries(obj).reduce<ObjectWithDefinedValues<T>>(
+): ValidTargetingObject<T> => {
+	const initialValue = {} as ValidTargetingObject<T>;
+	return Object.entries(obj).reduce<ValidTargetingObject<T>>(
 		(valid, [key, value]) => {
 			if (isValidTargeting(value)) {
 				// @ts-expect-error -- isValidTargeting checks this

--- a/src/targeting/pick-targeting-values.ts
+++ b/src/targeting/pick-targeting-values.ts
@@ -49,7 +49,9 @@ export const pickTargetingValues = <
 		(valid, [key, value]) => {
 			if (isValidTargeting(value)) {
 				// @ts-expect-error -- isValidTargeting checks this
-				valid[key] = value;
+				valid[key] = Array.isArray(value)
+					? value.filter(isTargetingString)
+					: value;
 			}
 
 			return valid;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6961,6 +6961,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.8.0.tgz#39d7c9f9c508df8d6ce1cf5a966b0e6568dcc50d"
+  integrity sha512-O+V9pAshf9C6loGaH0idwsmugI2LxVNR7DtS40gVo2EXZVYFgz9OuNtOhgHLdHdapOEWNdvz9Ob/eeuaWwwlxA==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"


### PR DESCRIPTION
## What does this change?

- Fix an issue with arrays of valid and invalid strings
- Lean `type-fest` for the funny type
- Update tests to cover more explicitly what the type does

## Why?

Easier to read!