### PR TITLE
fix: A little more type safety

### DIFF
--- a/src/targeting/pick-targeting-values.ts
+++ b/src/targeting/pick-targeting-values.ts
@@ -3,7 +3,14 @@ import type { ConditionalExcept } from 'type-fest';
 
 type ValidTargetingObject<Base> = ConditionalExcept<
 	Base,
-	null | undefined | '' | readonly [] | readonly [''] | boolean | number
+	| null
+	| undefined
+	| ''
+	| readonly []
+	| readonly ['']
+	| never[]
+	| boolean
+	| number
 >;
 
 const isTargetingString = (string: unknown): boolean =>


### PR DESCRIPTION
## What does this change?

Disallow `never[]`

## Why?

If you don’t use the `as const` assertion, you still get quite a lot of type safety.

Follow up on #xxx