### PR TITLE
feat: unify getSessionTargeting API

### DIFF
--- a/src/targeting/content.ts
+++ b/src/targeting/content.ts
@@ -99,6 +99,15 @@ const getUrlKeywords = (url: SharedTargeting['url']): string[] => {
 
 /* -- Targeting -- */
 
+type Content = {
+	eligibleForDCR: boolean;
+	path: SharedTargeting['url'];
+	renderingPlatform: ContentTargeting['rp'];
+	section: ContentTargeting['s'];
+	sensitive: boolean;
+	videoLength?: number;
+};
+
 export const getContentTargeting = ({
 	eligibleForDCR,
 	path,
@@ -106,14 +115,7 @@ export const getContentTargeting = ({
 	section,
 	sensitive,
 	videoLength,
-}: {
-	eligibleForDCR: boolean;
-	path: SharedTargeting['url'];
-	renderingPlatform: ContentTargeting['rp'];
-	section: ContentTargeting['s'];
-	sensitive: boolean;
-	videoLength?: number;
-}): ContentTargeting => {
+}: Content): ContentTargeting => {
 	return {
 		dcre: eligibleForDCR ? 't' : 'f',
 		rp: renderingPlatform,

--- a/src/targeting/session.spec.ts
+++ b/src/targeting/session.spec.ts
@@ -12,14 +12,17 @@ describe('Session targeting', () => {
 			si: 'f',
 		};
 
-		const targeting = getSessionTargeting(
-			'',
-			{
+		const targeting = getSessionTargeting({
+			referrer: '',
+			participations: {
 				serverSideParticipations: {},
 				clientSideParticipations: {},
 			},
-			{ at: null, pv: '1234567', cc: 'GB', si: 'f' },
-		);
+			adTest: null,
+			pageViewId: '1234567',
+			countryCode: 'GB',
+			isSignedIn: false,
+		});
 		expect(targeting).toMatchObject(expected);
 	});
 
@@ -34,12 +37,15 @@ describe('Session targeting', () => {
 				},
 			},
 			serverSideParticipations: {
-				abStandaloneBundle: 'variant',
+				abStandaloneBundleVariant: 'variant',
 			},
 		};
 
 		const expected: SessionTargeting = {
-			ab: ['ab-new-ad-targeting-variant', 'abStandaloneBundle-variant'],
+			ab: [
+				'ab-new-ad-targeting-variant',
+				'abStandaloneBundleVariant-variant',
+			],
 			at: null,
 			cc: 'GB',
 			pv: '1234567',
@@ -47,11 +53,13 @@ describe('Session targeting', () => {
 			si: 'f',
 		};
 
-		const targeting = getSessionTargeting('', participations, {
-			at: null,
-			pv: '1234567',
-			cc: 'GB',
-			si: 'f',
+		const targeting = getSessionTargeting({
+			referrer: '',
+			participations,
+			adTest: null,
+			pageViewId: '1234567',
+			countryCode: 'GB',
+			isSignedIn: false,
 		});
 		expect(targeting).toMatchObject(expected);
 	});
@@ -74,16 +82,17 @@ describe('Session targeting', () => {
 			ref,
 		};
 
-		const targeting = getSessionTargeting(
+		const targeting = getSessionTargeting({
 			referrer,
-			{ serverSideParticipations: {}, clientSideParticipations: {} },
-			{
-				at: null,
-				pv: '1234567',
-				cc: 'GB',
-				si: 'f',
+			participations: {
+				serverSideParticipations: {},
+				clientSideParticipations: {},
 			},
-		);
+			adTest: null,
+			pageViewId: '1234567',
+			countryCode: 'GB',
+			isSignedIn: false,
+		});
 		expect(targeting).toMatchObject(expected);
 	});
 });

--- a/src/targeting/session.spec.ts
+++ b/src/targeting/session.spec.ts
@@ -95,4 +95,31 @@ describe('Session targeting', () => {
 		});
 		expect(targeting).toMatchObject(expected);
 	});
+
+	const signedInOptions: Array<[boolean, SessionTargeting['si']]> = [
+		[true, 't'],
+		[false, 'f'],
+	];
+
+	test.each(signedInOptions)(
+		'should get `%s` for isSignedIn: %s',
+		(isSignedIn, si) => {
+			const expected: Pick<SessionTargeting, 'si'> = {
+				si,
+			};
+
+			const targeting = getSessionTargeting({
+				referrer: '',
+				participations: {
+					serverSideParticipations: {},
+					clientSideParticipations: {},
+				},
+				adTest: null,
+				pageViewId: '1234567',
+				countryCode: 'GB',
+				isSignedIn,
+			});
+			expect(targeting).toMatchObject(expected);
+		},
+	);
 });

--- a/src/targeting/session.ts
+++ b/src/targeting/session.ts
@@ -108,7 +108,10 @@ export type SessionTargeting = {
 
 export type AllParticipations = {
 	clientSideParticipations: Participations;
-	serverSideParticipations: Record<string, 'control' | 'variant'>;
+	serverSideParticipations: {
+		[key: `${string}Control`]: 'control';
+		[key: `${string}Variant`]: 'variant';
+	};
 };
 
 /* -- Methods -- */
@@ -155,12 +158,27 @@ const experimentsTargeting = ({
 
 /* -- Targeting -- */
 
-export const getSessionTargeting = (
-	referrer: string,
-	participations: AllParticipations,
-	targeting: Omit<SessionTargeting, 'ab' | 'ref'>,
-): SessionTargeting => ({
-	ref: getReferrer(referrer),
+type Session = {
+	adTest: SessionTargeting['at'];
+	countryCode: CountryCode;
+	isSignedIn: boolean;
+	pageViewId: SessionTargeting['pv'];
+	participations: AllParticipations;
+	referrer: string;
+};
+
+export const getSessionTargeting = ({
+	adTest,
+	countryCode,
+	isSignedIn,
+	pageViewId,
+	participations,
+	referrer,
+}: Session): SessionTargeting => ({
 	ab: experimentsTargeting(participations),
-	...targeting,
+	at: adTest,
+	cc: countryCode,
+	pv: pageViewId,
+	ref: getReferrer(referrer),
+	si: isSignedIn ? 't' : 'f',
 });


### PR DESCRIPTION
## What does this change?

Unify the API to match other `get*Targeting` methods

## Why?

Consistency!