### PR TITLE
feat: Add `getTuple` helper function to `ad-sizes.ts`

### DIFF
--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -1,4 +1,4 @@
-import { _ } from './ad-sizes';
+import { _, getTuple } from './ad-sizes';
 
 const { getAdSize } = _;
 
@@ -16,6 +16,23 @@ describe('ad sizes', () => {
 			expect(adSize.width).toEqual(expectedWidth);
 			expect(adSize.height).toEqual(expectedHeight);
 			expect(adSize.toString()).toEqual(expectedString);
+		},
+	);
+});
+
+describe('getTuple', () => {
+	it.each([
+		['mpu' as const, [300, 250]],
+		['fluid' as const, [0, 0]],
+		['googleCard' as const, [300, 274]],
+		['outstreamGoogleDesktop' as const, [550, 310]],
+		['video' as const, [620, 1]],
+		['300x600' as const, [300, 600]],
+	])(
+		'getTuple(%s: SizeKey) outputs tuple [$d, %d]',
+		(input, expectedTuple) => {
+			const tuple = getTuple(input);
+			expect(tuple).toEqual(expectedTuple);
 		},
 	);
 });

--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -1,4 +1,6 @@
+import type { AdSizeTuple } from './ad-sizes';
 import { _, getTuple } from './ad-sizes';
+import type { SizeKeys } from '.';
 
 const { getAdSize } = _;
 
@@ -20,15 +22,17 @@ describe('ad sizes', () => {
 	);
 });
 
+const sizes: Array<[SizeKeys, AdSizeTuple]> = [
+	['mpu', [300, 250]],
+	['fluid', [0, 0]],
+	['googleCard', [300, 274]],
+	['outstreamGoogleDesktop', [550, 310]],
+	['video', [620, 1]],
+	['300x600', [300, 600]],
+];
+
 describe('getTuple', () => {
-	it.each([
-		['mpu' as const, [300, 250]],
-		['fluid' as const, [0, 0]],
-		['googleCard' as const, [300, 274]],
-		['outstreamGoogleDesktop' as const, [550, 310]],
-		['video' as const, [620, 1]],
-		['300x600' as const, [300, 600]],
-	])(
+	it.each(sizes)(
 		'getTuple(%s: SizeKey) outputs tuple [$d, %d]',
 		(input, expectedTuple) => {
 			const tuple = getTuple(input);

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -6,6 +6,8 @@ export type AdSize = Readonly<{
 	toString: () => AdSizeString;
 }>;
 
+export type AdSizeTuple = [width: number, height: number];
+
 export type SizeKeys =
 	| 'billboard'
 	| 'leaderboard'
@@ -81,6 +83,12 @@ export const adSizes: Record<SizeKeys, AdSize> = {
 	'300x600': adSizesPartial.halfPage,
 	'300x1050': adSizesPartial.portrait,
 	'160x600': adSizesPartial.skyscraper,
+};
+
+export const getTuple = (size: SizeKeys): AdSizeTuple => {
+	const { width, height } = adSizes[size];
+	const tuple: AdSizeTuple = [width, height];
+	return tuple;
 };
 
 // Export for testing


### PR DESCRIPTION
As outlined in this [ticket](https://trello.com/c/nakVaVsO/1659-add-gettuple-method-to-commercial-core-ad-sizes), now that ad sizes have moved over to commercial core it makes sense for some helper functions to join them. This adds a `getTuple` function and `AdSizeTuple` type to `ad-sizes.ts`.
