### PR TITLE
feat: Replace `getTuple` with `getAdSize`

### DIFF
--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -1,8 +1,7 @@
-import type { AdSizeTuple } from './ad-sizes';
-import { _, getTuple } from './ad-sizes';
+import { _, getAdSize } from './ad-sizes';
 import type { SizeKeys } from '.';
 
-const { getAdSize } = _;
+const { createAdSize } = _;
 
 describe('ad sizes', () => {
 	it.each([
@@ -12,9 +11,9 @@ describe('ad sizes', () => {
 		[970, 250, '970,250'],
 		[0, 0, 'fluid'],
 	])(
-		'getAdSize(%d,%d) outputs string "%s"',
+		'createAdSize(%d,%d) outputs string "%s"',
 		(expectedWidth, expectedHeight, expectedString) => {
-			const adSize = getAdSize(expectedWidth, expectedHeight);
+			const adSize = createAdSize(expectedWidth, expectedHeight);
 			expect(adSize.width).toEqual(expectedWidth);
 			expect(adSize.height).toEqual(expectedHeight);
 			expect(adSize.toString()).toEqual(expectedString);
@@ -22,21 +21,23 @@ describe('ad sizes', () => {
 	);
 });
 
-const sizes: Array<[SizeKeys, AdSizeTuple]> = [
-	['mpu', [300, 250]],
-	['fluid', [0, 0]],
-	['googleCard', [300, 274]],
-	['outstreamGoogleDesktop', [550, 310]],
-	['video', [620, 1]],
-	['300x600', [300, 600]],
+const sizes: Array<[SizeKeys, number, number, string]> = [
+	['mpu', 300, 250, '300,250'],
+	['fluid', 0, 0, 'fluid'],
+	['googleCard', 300, 274, '300,274'],
+	['outstreamGoogleDesktop', 550, 310, '550,310'],
+	['video', 620, 1, '620,1'],
+	['300x600', 300, 600, '300,600'],
 ];
 
-describe('getTuple', () => {
+describe('getAdSize', () => {
 	it.each(sizes)(
-		'getTuple(%s: SizeKey) outputs tuple [$d, %d]',
-		(input, expectedTuple) => {
-			const tuple = getTuple(input);
-			expect(tuple).toEqual(expectedTuple);
+		'getAdSize(%s: SizeKey) outputs ad size {width: $d, height: %d}',
+		(input, expectedWidth, expectedHeight, expectedString) => {
+			const adSize = getAdSize(input);
+			expect(adSize.width).toEqual(expectedWidth);
+			expect(adSize.height).toEqual(expectedHeight);
+			expect(adSize.toString()).toEqual(expectedString);
 		},
 	);
 });

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -6,8 +6,6 @@ export type AdSize = Readonly<{
 	toString: () => AdSizeString;
 }>;
 
-export type AdSizeTuple = [width: number, height: number];
-
 export type SizeKeys =
 	| 'billboard'
 	| 'leaderboard'
@@ -36,7 +34,7 @@ export type SizeKeys =
 	| '300x1050'
 	| '160x600';
 
-const getAdSize = (width: number, height: number): AdSize => {
+const createAdSize = (width: number, height: number): AdSize => {
 	const toString = (): AdSizeString =>
 		width === 0 && height === 0 ? 'fluid' : `${width},${height}`;
 
@@ -49,30 +47,30 @@ const getAdSize = (width: number, height: number): AdSize => {
 
 const adSizesPartial = {
 	// standard ad sizes
-	billboard: getAdSize(970, 250),
-	leaderboard: getAdSize(728, 90),
-	mpu: getAdSize(300, 250),
-	halfPage: getAdSize(300, 600),
-	portrait: getAdSize(300, 1050),
-	skyscraper: getAdSize(160, 600),
-	mobilesticky: getAdSize(320, 50),
+	billboard: createAdSize(970, 250),
+	leaderboard: createAdSize(728, 90),
+	mpu: createAdSize(300, 250),
+	halfPage: createAdSize(300, 600),
+	portrait: createAdSize(300, 1050),
+	skyscraper: createAdSize(160, 600),
+	mobilesticky: createAdSize(320, 50),
 
 	// dfp proprietary ad sizes
-	fluid: getAdSize(0, 0),
-	outOfPage: getAdSize(1, 1),
-	googleCard: getAdSize(300, 274),
+	fluid: createAdSize(0, 0),
+	outOfPage: createAdSize(1, 1),
+	googleCard: createAdSize(300, 274),
 
 	// guardian proprietary ad sizes
-	video: getAdSize(620, 1),
-	outstreamDesktop: getAdSize(620, 350),
-	outstreamGoogleDesktop: getAdSize(550, 310),
-	outstreamMobile: getAdSize(300, 197),
-	merchandisingHighAdFeature: getAdSize(88, 89),
-	merchandisingHigh: getAdSize(88, 87),
-	merchandising: getAdSize(88, 88),
-	inlineMerchandising: getAdSize(88, 85),
-	fabric: getAdSize(88, 71),
-	empty: getAdSize(2, 2),
+	video: createAdSize(620, 1),
+	outstreamDesktop: createAdSize(620, 350),
+	outstreamGoogleDesktop: createAdSize(550, 310),
+	outstreamMobile: createAdSize(300, 197),
+	merchandisingHighAdFeature: createAdSize(88, 89),
+	merchandisingHigh: createAdSize(88, 87),
+	merchandising: createAdSize(88, 88),
+	inlineMerchandising: createAdSize(88, 85),
+	fabric: createAdSize(88, 71),
+	empty: createAdSize(2, 2),
 };
 
 export const adSizes: Record<SizeKeys, AdSize> = {
@@ -85,11 +83,7 @@ export const adSizes: Record<SizeKeys, AdSize> = {
 	'160x600': adSizesPartial.skyscraper,
 };
 
-export const getTuple = (size: SizeKeys): AdSizeTuple => {
-	const { width, height } = adSizes[size];
-	const tuple: AdSizeTuple = [width, height];
-	return tuple;
-};
+export const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
 
 // Export for testing
-export const _ = { getAdSize };
+export const _ = { createAdSize };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export { remarketing } from './third-party-tags/remarketing';
 export { EventTimer } from './EventTimer';
 export { sendCommercialMetrics } from './sendCommercialMetrics';
 export type { ThirdPartyTag } from './types';
-export { adSizes } from './ad-sizes';
+export { adSizes, getAdSize } from './ad-sizes';
 export type { SizeKeys, AdSizeString, AdSize } from './ad-sizes';
 export { isAdBlockInUse } from './detectAdBlocker';
 export {


### PR DESCRIPTION
Refactor previous PR by replacing `getTuple` with `getAdSize` and changing the old `getAdSize` to a more accurate `createAdSize`. The tuples are no more. Also fix exports so imports from the @guardian/commercial-core package works properly.

This was the product of a mobbing session with @ashishpuliyel, @arelra, and @simonbyford in which we questioned what a tuple ( `[width: number, height: number]` ) offered which the `AdSize` object below doesn't: 

```
{
        width: number;
	height: number;
	toString: () => AdSizeString;
}
``` 

Both contained width and height values, the latter just has a handy custom `toString` function. This seemed like a good opportunity to streamline the code, and will be followed up on with a corresponding PR in Frontend.
