### PR TITLE
fix(EventTimer): private constructor and rely on `performance.mark()`’s return

### DIFF
--- a/src/EventTimer.spec.ts
+++ b/src/EventTimer.spec.ts
@@ -19,20 +19,21 @@ const mockGetEntriesByName = (names: string[]) =>
 			: [],
 	);
 
+const mockMark = jest.fn(
+	(name: string): PerformanceMark => ({
+		name,
+		duration: 1,
+		entryType: 'mark',
+		startTime: 1,
+		detail: {},
+		toJSON: () => '',
+	}),
+);
+
 const performance = {
 	now: jest.fn(),
-	mark: jest.fn(),
-	getEntriesByName: jest
-		.fn()
-		.mockReturnValueOnce([
-			{
-				duration: 1,
-				entryType: 'mark',
-				name: 'commercial event',
-				startTime: 1,
-			},
-		])
-		.mockReturnValue([]),
+	mark: mockMark,
+	getEntriesByName: jest.fn().mockReturnValue([]),
 };
 
 const MARK_NAME = 'mark_name';
@@ -84,7 +85,7 @@ describe('EventTimer', () => {
 	it('get correct cmp events with additional event mark', () => {
 		const performanceCMP = {
 			now: jest.fn(),
-			mark: jest.fn(),
+			mark: mockMark,
 			getEntriesByName: mockGetEntriesByName([
 				MARK_LONG_NAME,
 				CMP_INIT,
@@ -128,7 +129,7 @@ describe('EventTimer', () => {
 	it('when retrieved and mark is undefined produce no events', () => {
 		const performance = {
 			now: jest.fn(),
-			mark: jest.fn(),
+			mark: undefined,
 			getEntriesByName: jest.fn().mockReturnValue([]),
 		};
 		Object.defineProperty(window, 'performance', {

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -106,7 +106,7 @@ export class EventTimer {
 			: this._events;
 	}
 
-	constructor() {
+	private constructor() {
 		this._events = [];
 		this.startTS = window.performance.now();
 		this.triggers = {

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -215,11 +215,12 @@ export class EventTimer {
 		const longName = `gu.commercial.${name}`;
 		if (
 			typeof window.performance !== 'undefined' &&
-			'mark' in window.performance
+			'mark' in window.performance &&
+			typeof window.performance.mark === 'function'
 		) {
 			const mark = window.performance.mark(longName);
-			// Most recent mark with this name is the event we just created.
-			if (typeof mark !== 'undefined') {
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- browser support is patchy
+			if (typeof mark?.startTime === 'number') {
 				this._events.push(new Event(name, mark));
 			}
 		}

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -88,19 +88,17 @@ export class EventTimer {
 			? [
 					...this._events,
 					...EventTimer._externallyDefinedEventNames
-						.filter(
-							(eventName) =>
-								window.performance.getEntriesByName(eventName)
-									.length,
-						)
-						.map(
-							(eventName) =>
-								new Event(
+						.map((eventName) => {
+							const entry =
+								window.performance.getEntriesByName(
 									eventName,
-									window.performance.getEntriesByName(
-										eventName,
-									)[0] as PerformanceEntry,
-								),
+								)[0];
+							return entry
+								? new Event(eventName, entry)
+								: undefined;
+						})
+						.filter(
+							(entry): entry is Event => entry instanceof Event,
 						),
 			  ]
 			: this._events;

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -217,11 +217,8 @@ export class EventTimer {
 			typeof window.performance !== 'undefined' &&
 			'mark' in window.performance
 		) {
-			window.performance.mark(longName);
+			const mark = window.performance.mark(longName);
 			// Most recent mark with this name is the event we just created.
-			const mark = window.performance
-				.getEntriesByName(longName, 'mark')
-				.slice(-1)[0];
 			if (typeof mark !== 'undefined') {
 				this._events.push(new Event(name, mark));
 			}


### PR DESCRIPTION
## What does this change?

### 1. `private constructor()`
Make the constructor private, to prevent people from doing `new EventTimer()` instead of `EventTimer.get()`.

### 2. `performance.mark()` returns a `mark`
Rely on the fact `performance.mark` returns the mark it created, so use that instead of going through all the marks and getting the last one. Fixed the tests so the mocks more closely match browser implementation.

### 3. `filter().map()` &rarr; `map().filter()`
The filtering of events is flipped so as to get rid of a type assertion. For `_externallyDefinedEventNames`, we now check if an entry exists, return an `Event` from it if id does, and return `undefined` otherwise. Then filter the resulting array for entries that are instances of `Event`.

## Why?

Cleaner, probably faster, uses returns types from the API.