### PR TITLE
docs: Small updates to spacefinder readme

### DIFF
--- a/docs/spacefinder/readme.md
+++ b/docs/spacefinder/readme.md
@@ -53,7 +53,7 @@ Rules are currently set in [`article-body-adverts.js`][] in the frontend reposit
 
 ### Desktop
 
-#### First round (`defaultRules`)
+#### First round (`defaultRules`) - skipped for paid content pages
 
 - At least 300px of space above (700px on immersive pages)
 - At least 300px of space below (700px if `isDotcomRendering` returns `false`)

--- a/docs/spacefinder/readme.md
+++ b/docs/spacefinder/readme.md
@@ -37,7 +37,7 @@ Or to simplify it further:
 
 The value names above are made up to try to boil the essentials down - they don’t match what’s going on in the code itself. The ad heights mentioned are pulled in from [`ad-sizes.js`][].
 
-[`ad-sizes.js`]: https://github.com/guardian/frontend/blob/cd3dc40766710a8931357c1fa50a5a5c7c6de961/static/src/javascripts.flow.archive/projects/commercial/modules/ad-sizes.js
+[`ad-sizes.js`]: https://github.com/guardian/commercial-core/blob/main/src/ad-sizes.ts
 
 ---
 

--- a/docs/spacefinder/readme.md
+++ b/docs/spacefinder/readme.md
@@ -49,7 +49,7 @@ The value names above are made up to try to boil the essentials down - they donâ
 
 Rules are currently set in [`article-body-adverts.js`][] in the frontend repository. The desktop configuration sits inside `addDesktopInlineAds`, which has two sets of rules. The mobile configuration is inside `addMobileInlineAds`.
 
-[`article-body-adverts.js`]: https://github.com/guardian/frontend/blob/cd3dc40766710a8931357c1fa50a5a5c7c6de961/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+[`article-body-adverts.js`]: https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
 
 ### Desktop
 


### PR DESCRIPTION
## What does this change?

Makes some minor updates to the spacefinder readme

## Why?

To improve its accuracy

## TODO:

I have noticed the readme doesn't cover one part of the process which is the [attempted insertion of an inline merchandising ad](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/commercial/modules/article-body-adverts.js#L239-L241). This happens before the inline ads are inserted. Depending on how exhaustive the docs are supposed to be (potentially not very..?) we should probably add a note about this too.