### PR TITLE
feat: Export ad targeting and adjust `getViewportTargeting` arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,3 +26,14 @@ export type {
 	CustomParams,
 } from './types';
 export * as constants from './constants';
+export type { ContentTargeting } from './targeting/content';
+export { getContentTargeting } from './targeting/content';
+export type { PersonalisedTargeting } from './targeting/personalised';
+export { getPersonalisedTargeting } from './targeting/personalised';
+export type { SessionTargeting } from './targeting/session';
+export { getSessionTargeting } from './targeting/session';
+export type { SharedTargeting } from './targeting/shared';
+export { getSharedTargeting } from './targeting/shared';
+export type { ViewportTargeting } from './targeting/viewport';
+export { getViewportTargeting } from './targeting/viewport';
+export { pickTargetingValues } from './targeting/pick-targeting-values';

--- a/src/targeting/viewport.spec.ts
+++ b/src/targeting/viewport.spec.ts
@@ -8,7 +8,10 @@ describe('Viewport targeting', () => {
 			inskin: 't',
 			skinsize: 's',
 		};
-		const targeting = getViewportTargeting(1280, false);
+		const targeting = getViewportTargeting({
+			viewPortWidth: 1280,
+			cmpBannerWillShow: false,
+		});
 		expect(targeting).toMatchObject(expected);
 	});
 
@@ -18,7 +21,10 @@ describe('Viewport targeting', () => {
 			inskin: 'f',
 			skinsize: 's',
 		};
-		const targeting = getViewportTargeting(1280, true);
+		const targeting = getViewportTargeting({
+			viewPortWidth: 1280,
+			cmpBannerWillShow: true,
+		});
 		expect(targeting).toMatchObject(expected);
 	});
 
@@ -52,7 +58,10 @@ describe('Viewport targeting', () => {
 				skinsize,
 			};
 
-			const targeting = getViewportTargeting(windowWidth, false);
+			const targeting = getViewportTargeting({
+				viewPortWidth: windowWidth,
+				cmpBannerWillShow: false,
+			});
 			expect(targeting).toMatchObject(expected);
 		},
 	);

--- a/src/targeting/viewport.ts
+++ b/src/targeting/viewport.ts
@@ -55,10 +55,15 @@ const findBreakpoint = (width: number): ViewportTargeting['bp'] => {
 
 /* -- Targeting -- */
 
-export const getViewportTargeting = (
-	viewPortWidth: number,
-	cmpBannerWillShow: boolean,
-): ViewportTargeting => {
+type Viewport = {
+	viewPortWidth: number;
+	cmpBannerWillShow: boolean;
+};
+
+export const getViewportTargeting = ({
+	viewPortWidth,
+	cmpBannerWillShow,
+}: Viewport): ViewportTargeting => {
 	// Don’t show inskin if if a privacy message will be shown
 	const inskin = cmpBannerWillShow ? 'f' : 't';
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Export functions and types related to ad targeting, introduced in feature branches
- https://github.com/guardian/commercial-core/pull/421
- https://github.com/guardian/commercial-core/pull/422
- https://github.com/guardian/commercial-core/pull/423
- https://github.com/guardian/commercial-core/pull/424
- https://github.com/guardian/commercial-core/pull/455

This will replace the ad targeting implementations in Frontend and DCR (where targeting on AMP is different to that in the commercial bundle), after the changes in [Frontend #24498](https://github.com/guardian/frontend/pull/24498).

Secondly, this PR includes a small change to the type of `getViewportTargeting`, making it take an object rather than two arguments. This is so that it has a similar interface to the other targeting functions (note personalised does not have this interface as it only takes consent state as its sole argument).

## Why?

So that we can access these types/functions in Frontend/DCR from the root of the package rather than a long path, for example

```typescript
import { getSessionTargeting } from '@guardian/commercial-core'
```
