### PR TITLE
fix(targeting): Change minimum tablet width

### DIFF
--- a/src/targeting/viewport.spec.ts
+++ b/src/targeting/viewport.spec.ts
@@ -26,10 +26,10 @@ describe('Viewport targeting', () => {
 		[number, ViewportTargeting['bp'], ViewportTargeting['skinsize']]
 	> = [
 		[320, 'mobile', 's'],
-		[640, 'mobile', 's'],
-		[739, 'mobile', 's'],
+		[370, 'mobile', 's'],
+		[470, 'mobile', 's'],
 
-		[750, 'tablet', 's'],
+		[670, 'tablet', 's'],
 		[960, 'tablet', 's'],
 
 		[1024, 'desktop', 's'],

--- a/src/targeting/viewport.ts
+++ b/src/targeting/viewport.ts
@@ -49,7 +49,7 @@ export type ViewportTargeting = {
 
 const findBreakpoint = (width: number): ViewportTargeting['bp'] => {
 	if (width >= 980) return 'desktop';
-	if (width >= 740) return 'tablet';
+	if (width >= 660) return 'tablet';
 	return 'mobile';
 };
 


### PR DESCRIPTION
## What does this change?

Adjust the minimum width of the viewport for `findBreakpoint` to output `tablet` from `740` (the width of the `tablet` breakpoint) to `660` (the width of the `phablet` breakpoint).

Update the tests to reflect this change.

## Why?

To match the current implementation in [Frontend](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts#L113-L128), where `phablet` width `660` also maps to `tablet` when generating page targeting.

