### PR TITLE
feat: Update event timer names

### DIFF
--- a/src/EventTimer.spec.ts
+++ b/src/EventTimer.spec.ts
@@ -231,13 +231,13 @@ describe('EventTimer', () => {
 
 	it('trigger commercial end page event', () => {
 		const eventTimer = EventTimer.get();
-		eventTimer.trigger('commercialEnd');
+		eventTimer.trigger('commercialModulesLoaded');
 		expect((window.performance.mark as jest.Mock).mock.calls).toEqual([
-			['gu.commercial.commercialEnd'],
+			['gu.commercial.commercialModulesLoaded'],
 		]);
 		expect(trackEvent).toHaveBeenCalledWith(
 			'Commercial Events',
-			'commercialEnd',
+			'commercialModulesLoaded',
 			'Commercial end parse time',
 		);
 	});

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -28,6 +28,8 @@ interface SlotEventStatus {
 
 interface PageEventStatus {
 	commercialStart: boolean;
+	commercialExtraModulesLoaded: boolean;
+	commercialBaseModulesLoaded: boolean;
 	commercialModulesLoaded: boolean;
 }
 
@@ -124,6 +126,8 @@ export class EventTimer {
 			},
 			page: {
 				commercialStart: false,
+				commercialExtraModulesLoaded: false,
+				commercialBaseModulesLoaded: false,
 				commercialModulesLoaded: false,
 			},
 		};

--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -28,7 +28,7 @@ interface SlotEventStatus {
 
 interface PageEventStatus {
 	commercialStart: boolean;
-	commercialEnd: boolean;
+	commercialModulesLoaded: boolean;
 }
 
 export class EventTimer {
@@ -124,7 +124,7 @@ export class EventTimer {
 			},
 			page: {
 				commercialStart: false,
-				commercialEnd: false,
+				commercialModulesLoaded: false,
 			},
 		};
 
@@ -141,7 +141,7 @@ export class EventTimer {
 					timingLabel: 'Commercial start parse time',
 				},
 				{
-					timingVariable: 'commercialEnd',
+					timingVariable: 'commercialModulesLoaded',
 					timingLabel: 'Commercial end parse time',
 				},
 			],


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Makes changes 2 and 3 from the diagram below:
- Renames the commercial timer event `commercialEnd` to `commercialModulesLoaded`
- Adds two commercial metrics, `commercialExtraModulesLoaded` and `commercialBaseModulesLoaded`

![Screenshot 2022-02-08 at 17 36 59](https://user-images.githubusercontent.com/17057932/153043960-bb4f0025-ff4c-4284-8265-9832fd08bfea.png)

## Why?
- The change from `commercialEnd` to `commercialModulesLoaded` reflects what has actually occurred when the metric is triggered; All commercial modules have been loaded (but haven't necessarily finished executing), but since more commercial events (e.g. initialising the first slot and showing the first ad) have yet to happen, `commercialEnd` could be misleading.
- `commercialExtraModulesLoaded` and `commercialBaseModulesLoaded` are [already being triggered](https://github.com/guardian/frontend/blob/fed5c0cbf116e432d1bdb58d64ce7d8ad904b386/static/src/javascripts/bootstraps/standalone.commercial.ts#L170) so their addition here is just to keep commercial-core up to date with frontend

