### PR TITLE
feat!: Add properties `numInlineSlots` and `totalSlots` to commercial metrics

### DIFF
--- a/src/sendCommercialMetrics.spec.ts
+++ b/src/sendCommercialMetrics.spec.ts
@@ -37,13 +37,13 @@ const defaultMetrics = {
 };
 
 const mockSendMetrics = () =>
-	initCommercialMetrics(
-		PAGE_VIEW_ID,
-		BROWSER_ID,
-		IS_NOT_DEV,
-		ADBLOCK_NOT_IN_USE,
-		USER_IN_SAMPLING,
-	);
+	initCommercialMetrics({
+		pageViewId: PAGE_VIEW_ID,
+		browserId: BROWSER_ID,
+		isDev: IS_NOT_DEV,
+		adBlockerInUse: ADBLOCK_NOT_IN_USE,
+		sampling: USER_IN_SAMPLING,
+	});
 
 const setVisibility = (value: 'hidden' | 'visible' = 'hidden'): void => {
 	Object.defineProperty(document, 'visibilityState', {
@@ -116,13 +116,13 @@ describe('send commercial metrics code', () => {
 		});
 
 		it('should handle endpoint in dev', () => {
-			const mockSendMetrics = initCommercialMetrics(
-				PAGE_VIEW_ID,
-				BROWSER_ID,
-				IS_DEV,
-				ADBLOCK_NOT_IN_USE,
-				USER_IN_SAMPLING,
-			);
+			const mockSendMetrics = initCommercialMetrics({
+				pageViewId: PAGE_VIEW_ID,
+				browserId: BROWSER_ID,
+				isDev: IS_DEV,
+				adBlockerInUse: ADBLOCK_NOT_IN_USE,
+				sampling: USER_IN_SAMPLING,
+			});
 			setVisibility();
 			global.dispatchEvent(new Event('visibilitychange'));
 
@@ -175,13 +175,13 @@ describe('send commercial metrics code', () => {
 				downlink: 1,
 				effectiveType: '4g',
 			};
-			const sentMetrics = initCommercialMetrics(
-				PAGE_VIEW_ID,
-				BROWSER_ID,
-				IS_DEV,
-				ADBLOCK_NOT_IN_USE,
-				USER_IN_SAMPLING,
-			);
+			const sentMetrics = initCommercialMetrics({
+				pageViewId: PAGE_VIEW_ID,
+				browserId: BROWSER_ID,
+				isDev: IS_DEV,
+				adBlockerInUse: ADBLOCK_NOT_IN_USE,
+				sampling: USER_IN_SAMPLING,
+			});
 			setVisibility();
 			global.dispatchEvent(new Event('pagehide'));
 			expect(sentMetrics).toEqual(true);
@@ -202,23 +202,23 @@ describe('send commercial metrics code', () => {
 		});
 
 		it('should return false if user is not in sampling', () => {
-			const sentMetrics = initCommercialMetrics(
-				PAGE_VIEW_ID,
-				BROWSER_ID,
-				IS_NOT_DEV,
-				ADBLOCK_NOT_IN_USE,
-				USER_NOT_IN_SAMPLING,
-			);
+			const sentMetrics = initCommercialMetrics({
+				pageViewId: PAGE_VIEW_ID,
+				browserId: BROWSER_ID,
+				isDev: IS_NOT_DEV,
+				adBlockerInUse: ADBLOCK_NOT_IN_USE,
+				sampling: USER_NOT_IN_SAMPLING,
+			});
 			expect(sentMetrics).toEqual(false);
 		});
 
 		it('should set sampling at 0.01 if sampling is not passed in', () => {
-			const sentMetrics = initCommercialMetrics(
-				PAGE_VIEW_ID,
-				BROWSER_ID,
-				IS_NOT_DEV,
-				ADBLOCK_NOT_IN_USE,
-			);
+			const sentMetrics = initCommercialMetrics({
+				pageViewId: PAGE_VIEW_ID,
+				browserId: BROWSER_ID,
+				isDev: IS_NOT_DEV,
+				adBlockerInUse: ADBLOCK_NOT_IN_USE,
+			});
 			const mathRandomSpy = jest.spyOn(Math, 'random');
 			mathRandomSpy.mockImplementation(() => 0.5);
 			expect(sentMetrics).toEqual(false);
@@ -230,13 +230,13 @@ describe('send commercial metrics code', () => {
 				downlink: 1,
 				effectiveType: '4g',
 			};
-			const sentMetrics = initCommercialMetrics(
-				PAGE_VIEW_ID,
-				BROWSER_ID,
-				IS_DEV,
-				undefined,
-				USER_IN_SAMPLING,
-			);
+			const sentMetrics = initCommercialMetrics({
+				pageViewId: PAGE_VIEW_ID,
+				browserId: BROWSER_ID,
+				isDev: IS_DEV,
+				adBlockerInUse: undefined,
+				sampling: USER_IN_SAMPLING,
+			});
 			setVisibility();
 			global.dispatchEvent(new Event('pagehide'));
 			expect(sentMetrics).toEqual(true);

--- a/src/sendCommercialMetrics.spec.ts
+++ b/src/sendCommercialMetrics.spec.ts
@@ -235,6 +235,8 @@ describe('send commercial metrics code', () => {
 				browserId: BROWSER_ID,
 				isDev: IS_DEV,
 				adBlockerInUse: undefined,
+				numInlineSlots: 5,
+				totalSlots: 10,
 				sampling: USER_IN_SAMPLING,
 			});
 			setVisibility();
@@ -249,6 +251,8 @@ describe('send commercial metrics code', () => {
 							{ name: 'downlink', value: '1' },
 							{ name: 'effectiveType', value: '4g' },
 							{ name: 'isDev', value: 'localhost' },
+							{ name: 'numInlineSlots', value: '5' },
+							{ name: 'totalSlots', value: '10' },
 						],
 					}),
 				],

--- a/src/sendCommercialMetrics.ts
+++ b/src/sendCommercialMetrics.ts
@@ -45,6 +45,7 @@ let commercialMetricsPayload: CommercialMetricsPayload = {
 
 let devProperties: Property[] | [] = [];
 let adBlockerProperties: Property[] | [] = [];
+let slotProperties: Property[] | [] = [];
 let initialised = false;
 let endpoint: Endpoints;
 
@@ -66,6 +67,31 @@ const setAdBlockerProperties = (adBlockerInUse?: boolean): void => {
 					},
 			  ]
 			: [];
+};
+
+const setSlotProperties = (
+	numInlineSlots?: number,
+	totalSlots?: number,
+): void => {
+	const numInlineSlotsProperties =
+		numInlineSlots !== undefined
+			? [
+					{
+						name: 'numInlineSlots',
+						value: numInlineSlots.toString(),
+					},
+			  ]
+			: [];
+	const totalSlotsProperties =
+		totalSlots !== undefined
+			? [
+					{
+						name: 'totalSlots',
+						value: totalSlots.toString(),
+					},
+			  ]
+			: [];
+	slotProperties = numInlineSlotsProperties.concat(totalSlotsProperties);
 };
 
 const transformToObjectEntries = (
@@ -126,7 +152,8 @@ function gatherMetricsOnPageUnload(): void {
 
 	const properties: readonly Property[] = mappedEventTimerProperties
 		.concat(devProperties)
-		.concat(adBlockerProperties);
+		.concat(adBlockerProperties)
+		.concat(slotProperties);
 	commercialMetricsPayload.properties = properties;
 
 	const metrics: readonly Metric[] = roundTimeStamp(eventTimer.events);
@@ -173,6 +200,8 @@ interface InitCommercialMetricsArgs {
 	browserId: string | undefined;
 	isDev: boolean;
 	adBlockerInUse?: boolean;
+	numInlineSlots?: number;
+	totalSlots?: number;
 	sampling?: number;
 }
 
@@ -182,6 +211,8 @@ interface InitCommercialMetricsArgs {
  * @param init.browserId - identifies the browser. Usually available via `getCookie({ name: 'bwid' })`. Defaults to `null`
  * @param init.isDev - used to determine whether to use CODE or PROD endpoints.
  * @param init.adBlockerInUse - indicates whether or not an adblocker is being used.
+ * @param init.numInlineSlots - the number of inline ad slots on the page
+ * @param init.totalSlots - the total number of ad slots on the page
  * @param init.sampling - rate at which to sample commercial metrics - the default is to send for 1% of pageviews
  */
 export function initCommercialMetrics({
@@ -189,6 +220,8 @@ export function initCommercialMetrics({
 	browserId,
 	isDev,
 	adBlockerInUse,
+	numInlineSlots,
+	totalSlots,
 	sampling = 1 / 100,
 }: InitCommercialMetricsArgs): boolean {
 	commercialMetricsPayload.page_view_id = pageViewId;
@@ -196,6 +229,7 @@ export function initCommercialMetrics({
 	setEndpoint(isDev);
 	setDevProperties(isDev);
 	setAdBlockerProperties(adBlockerInUse);
+	setSlotProperties(numInlineSlots, totalSlots);
 
 	if (initialised) {
 		return false;

--- a/src/sendCommercialMetrics.ts
+++ b/src/sendCommercialMetrics.ts
@@ -168,20 +168,29 @@ export function bypassCommercialMetricsSampling(): void {
 	addVisibilityListeners();
 }
 
+interface InitCommercialMetricsArgs {
+	pageViewId: string;
+	browserId: string | undefined;
+	isDev: boolean;
+	adBlockerInUse?: boolean;
+	sampling?: number;
+}
+
 /**
  * A method to initialise metrics.
  * @param init.pageViewId - identifies the page view. Usually available on `guardian.config.ophan.pageViewId`. Defaults to `null`
  * @param init.browserId - identifies the browser. Usually available via `getCookie({ name: 'bwid' })`. Defaults to `null`
  * @param init.isDev - used to determine whether to use CODE or PROD endpoints.
- * @param init.adBlockerInUse - indicates whether or not ann adblocker is being used.
+ * @param init.adBlockerInUse - indicates whether or not an adblocker is being used.
+ * @param init.sampling - rate at which to sample commercial metrics - the default is to send for 1% of pageviews
  */
-export function initCommercialMetrics(
-	pageViewId: string,
-	browserId: string | undefined,
-	isDev: boolean,
-	adBlockerInUse?: boolean,
-	sampling: number = 1 / 100,
-): boolean {
+export function initCommercialMetrics({
+	pageViewId,
+	browserId,
+	isDev,
+	adBlockerInUse,
+	sampling = 1 / 100,
+}: InitCommercialMetricsArgs): boolean {
 	commercialMetricsPayload.page_view_id = pageViewId;
 	commercialMetricsPayload.browser_id = browserId;
 	setEndpoint(isDev);


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
- introduce two new commercial metrics
   - `numInlineSlots` - the number of inline ad slots on the page
   - `totalSlots` - the total number of ad slots on the page
- use parameter destructuring to simplify `initCommercialMetrics` api

## Why?
- It's necessary to collect `numInlineSlots` and `totalSlots` properties for the analysis of future A/B test around lazily-loaded ads on articles.
- adding the two new parameters to `initCommercialMetrics` brought the total arguments a caller could use to 7. Leaving these as positional arguments made the function more difficult to use. 
