### PR TITLE
feat: Collect commercial metrics on scroll depth

### DIFF
--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -39,6 +39,8 @@ interface EventTimerProperties {
 	effectiveType?: string;
 	adSlotsInline?: number;
 	adSlotsTotal?: number;
+	// the height of the page / the viewport height
+	pageHeightVH?: number;
 }
 
 export class EventTimer {
@@ -173,7 +175,16 @@ export class EventTimer {
 				: {};
 	}
 
-	setProperty(name: 'adSlotsInline' | 'adSlotsTotal', value: number): void {
+	/**
+	 * Adds an event timer property
+	 *
+	 * @param {string} name - the property's name
+	 * @param {value} number - the property's value
+	 */
+	setProperty(
+		name: 'adSlotsInline' | 'adSlotsTotal' | 'pageHeightVH',
+		value: number,
+	): void {
 		this.properties[name] = value;
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export {
 	getPermutiveSegments,
 	getPermutivePFPSegments,
 } from './permutive';
+export { initTrackScrollDepth } from './track-scroll-depth';
 export { buildAdsConfigWithConsent, disabledAds } from './ad-targeting-youtube';
 export type {
 	AdsConfig,

--- a/src/track-scroll-depth.spec.ts
+++ b/src/track-scroll-depth.spec.ts
@@ -1,0 +1,61 @@
+import { EventTimer } from './EventTimer';
+import { initTrackScrollDepth } from './track-scroll-depth';
+
+describe('initTrackScrollDepth', () => {
+	const observe = jest.fn();
+	class IntersectionObserver {
+		constructor() {
+			return Object.freeze({
+				observe: observe,
+				unobserve: () => {
+					return;
+				},
+			});
+		}
+	}
+
+	const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+		HTMLElement.prototype,
+		'offsetHeight',
+	);
+	beforeAll(() => {
+		Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+			configurable: true,
+			value: 1000,
+		});
+
+		Object.defineProperty(global, 'IntersectionObserver', {
+			value: IntersectionObserver,
+			writable: true,
+		});
+	});
+
+	afterAll(() => {
+		Object.defineProperty(
+			HTMLElement.prototype,
+			'offsetHeight',
+			originalOffsetHeight ?? 0,
+		);
+	});
+
+	test('Hidden elements are inserted and observed', () => {
+		// Given a 1000px page and a viewport height of 100px,
+		// 10 hidden elements are inserted
+		// NOTE we can't simulate scrolling down the page and assert that the callback
+		// to IntersectionObserver works as expected.
+		const eventTimer = EventTimer.get();
+		window.innerHeight = 100;
+
+		initTrackScrollDepth();
+
+		// height of viewport recorded
+		expect(eventTimer.properties['pageHeightVH']).toEqual(10);
+		const hiddenElements = document.querySelectorAll(
+			'.scroll-depth-marker',
+		);
+		// the hidden elements are inserted
+		expect(hiddenElements.length).toEqual(10);
+		// and observed
+		expect(observe).toHaveBeenCalledTimes(10);
+	});
+});

--- a/src/track-scroll-depth.spec.ts
+++ b/src/track-scroll-depth.spec.ts
@@ -6,7 +6,7 @@ describe('initTrackScrollDepth', () => {
 	class IntersectionObserver {
 		constructor() {
 			return Object.freeze({
-				observe: observe,
+				observe,
 				unobserve: () => {
 					return;
 				},

--- a/src/track-scroll-depth.spec.ts
+++ b/src/track-scroll-depth.spec.ts
@@ -41,8 +41,8 @@ describe('initTrackScrollDepth', () => {
 	test('Hidden elements are inserted and observed', () => {
 		// Given a 1000px page and a viewport height of 100px,
 		// 10 hidden elements are inserted
-		// NOTE we can't simulate scrolling down the page and assert that the callback
-		// to IntersectionObserver works as expected.
+		// NOTE we can't test the callback to IntersectionObserver
+		// since IntersectionObserver isn't available and has to be mocked.
 		const eventTimer = EventTimer.get();
 		window.innerHeight = 100;
 

--- a/src/track-scroll-depth.ts
+++ b/src/track-scroll-depth.ts
@@ -1,0 +1,39 @@
+import { EventTimer } from './EventTimer';
+
+/**
+ * Collect commercial metrics on scroll depth
+ * Insert hidden elements at intervals of 1 viewport height
+ * then use an intersection observer to mark the time when the viewport intersects with these elements.
+ */
+const initTrackScrollDepth = () => {
+	const body = document.querySelector('body');
+	if (body === null) return;
+	const pageHeight = body.offsetHeight;
+	const intViewportHeight = window.innerHeight;
+	// how many viewports tall is the page?
+	const pageHeightVH = Math.floor(pageHeight / intViewportHeight);
+	const eventTimer = EventTimer.get();
+	eventTimer.setProperty('pageHeightVH', pageHeightVH);
+
+	const observer = new IntersectionObserver((entries) => {
+		entries.forEach((entry) => {
+			if (entry.isIntersecting) {
+				const currentDepthVH = entry.target.getAttribute('data-depth');
+				console.log('current depth ', currentDepthVH);
+				eventTimer.trigger('scroll-depth-vh-' + String(currentDepthVH));
+				observer.unobserve(entry.target);
+			}
+		});
+	});
+
+	for (let depth = 1; depth <= pageHeightVH; depth++) {
+		const div = document.createElement('div');
+		div.dataset.depth = String(depth);
+		div.style.top = String(100 * depth) + '%';
+		div.style.position = 'absolute';
+		body.appendChild(div);
+		observer.observe(div);
+	}
+};
+
+export { initTrackScrollDepth };

--- a/src/track-scroll-depth.ts
+++ b/src/track-scroll-depth.ts
@@ -7,34 +7,36 @@ import { EventTimer } from './EventTimer';
  * then use an intersection observer to mark the time when the viewport intersects with these elements.
  */
 const initTrackScrollDepth = () => {
-	const body = document.querySelector('body');
-	if (body === null) return;
-	const pageHeight = body.offsetHeight;
+	const pageHeight = document.body.offsetHeight;
 	const intViewportHeight = window.innerHeight;
 	// how many viewports tall is the page?
 	const pageHeightVH = Math.floor(pageHeight / intViewportHeight);
 	const eventTimer = EventTimer.get();
 	eventTimer.setProperty('pageHeightVH', pageHeightVH);
 
-	const observer = new IntersectionObserver((entries) => {
-		entries.forEach((entry) => {
-			if (entry.isIntersecting) {
-				const currentDepthVH = String(
-					entry.target.getAttribute('data-depth'),
-				);
-				log('commercial', `current scroll depth ${currentDepthVH}`);
-				eventTimer.trigger(`scroll-depth-vh-${currentDepthVH}`);
-				observer.unobserve(entry.target);
-			}
-		});
-	});
+	const observer = new IntersectionObserver(
+		/* istanbul ignore next */
+		(entries) => {
+			entries.forEach((entry) => {
+				if (entry.isIntersecting) {
+					const currentDepthVH = String(
+						entry.target.getAttribute('data-depth'),
+					);
+					log('commercial', `current scroll depth ${currentDepthVH}`);
+					eventTimer.trigger(`scroll-depth-vh-${currentDepthVH}`);
+					observer.unobserve(entry.target);
+				}
+			});
+		},
+	);
 
 	for (let depth = 1; depth <= pageHeightVH; depth++) {
 		const div = document.createElement('div');
 		div.dataset.depth = String(depth);
 		div.style.top = String(100 * depth) + '%';
 		div.style.position = 'absolute';
-		body.appendChild(div);
+		div.className = 'scroll-depth-marker';
+		document.body.appendChild(div);
 		observer.observe(div);
 	}
 };

--- a/src/track-scroll-depth.ts
+++ b/src/track-scroll-depth.ts
@@ -5,6 +5,7 @@ import { EventTimer } from './EventTimer';
  * Collect commercial metrics on scroll depth
  * Insert hidden elements at intervals of 1 viewport height
  * then use an intersection observer to mark the time when the viewport intersects with these elements.
+ * Approach inspired by https://gist.github.com/bgreater/2412517f5a3f9c6fc4cafeb1ca71384f
  */
 const initTrackScrollDepth = () => {
 	const pageHeight = document.body.offsetHeight;

--- a/src/track-scroll-depth.ts
+++ b/src/track-scroll-depth.ts
@@ -1,3 +1,4 @@
+import { log } from '@guardian/libs';
 import { EventTimer } from './EventTimer';
 
 /**
@@ -18,9 +19,11 @@ const initTrackScrollDepth = () => {
 	const observer = new IntersectionObserver((entries) => {
 		entries.forEach((entry) => {
 			if (entry.isIntersecting) {
-				const currentDepthVH = entry.target.getAttribute('data-depth');
-				console.log('current depth ', currentDepthVH);
-				eventTimer.trigger('scroll-depth-vh-' + String(currentDepthVH));
+				const currentDepthVH = String(
+					entry.target.getAttribute('data-depth'),
+				);
+				log('commercial', `current scroll depth ${currentDepthVH}`);
+				eventTimer.trigger(`scroll-depth-vh-${currentDepthVH}`);
 				observer.unobserve(entry.target);
 			}
 		});


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Adds a function `initTrackScrollDepth` which collects commercial metrics on user scroll depth. It does this by inserting hidden elements at intervals of 1 viewport height, then using an intersection observer to mark the time when the viewport intersects with these elements with `EventTimer.trigger`.

## Why?
We'd like to be more accurate in finding the optimal moment to load lazily-loaded ads and suspect that there may be a possible solution that considers scroll velocity. We're temporarily collecting scroll depth metrics in order as background research to help us with this.

## Known issues
- There will be some noise from inaccurate scroll depth metrics due to users resizing their window after the page loads