### PR TITLE
feat: add property `lazyLoadMarginPercent` to `EventTimer`

### DIFF
--- a/src/EventTimer.ts
+++ b/src/EventTimer.ts
@@ -41,6 +41,8 @@ interface EventTimerProperties {
 	adSlotsTotal?: number;
 	// the height of the page / the viewport height
 	pageHeightVH?: number;
+	// distance in percentage of viewport height at which ads are lazy loaded
+	lazyLoadMarginPercent?: number;
 }
 
 export class EventTimer {
@@ -182,7 +184,11 @@ export class EventTimer {
 	 * @param {value} number - the property's value
 	 */
 	setProperty(
-		name: 'adSlotsInline' | 'adSlotsTotal' | 'pageHeightVH',
+		name:
+			| 'adSlotsInline'
+			| 'adSlotsTotal'
+			| 'pageHeightVH'
+			| 'lazyLoadMarginPercent',
 		value: number,
 	): void {
 		this.properties[name] = value;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
- Adds a new event timer property and allows it to be set by `setProperty`

## Why?
- As part of the [frontend experiment](https://github.com/guardian/frontend/pull/24770) to find an optimal lazy load margin, we need to be able to record the margin values used for the variant group.
