### PR TITLE
docs: Initial migration document

### DIFF
--- a/docs/migration/migration.md
+++ b/docs/migration/migration.md
@@ -3,6 +3,7 @@
 This document details requirements for moving code from Frontend to commercial-core.
 
 ## Entrance Requirements
+Modules should only be migrated from Frontend if they meet the following criteria: 
 
 - Side-effect free code whereever possible
 - Split logic where required to keep code side-effect free

--- a/docs/migration/migration.md
+++ b/docs/migration/migration.md
@@ -31,6 +31,7 @@ Larger, more complex lib functions we could invert control by passing as a depen
 
 # Desirable Patterns
 
+- Aim to include [TSDocs](https://tsdoc.org/) where appropriate, especially for exported functions that will be used in consuming packages / applications.
 - exports at the end of the file i.e. no inline exports
 - no exports just for testing
 - kebab-case

--- a/docs/migration/migration.md
+++ b/docs/migration/migration.md
@@ -5,11 +5,11 @@ This document details requirements for moving code from Frontend to commercial-c
 ## Entrance Requirements
 Modules should only be migrated from Frontend if they meet the following criteria: 
 
-- Side-effect free code whereever possible
+- Side-effect free code wherever possible
 - Split logic where required to keep code side-effect free
 - TypeScript
 - Unit tested
-- Where we check `isDotcomRendering` double check if that logic is still required i.e. DCR is gradually taking over the rendering of more features so its worth checking if any conditional platform checks are still required.
+- Where we check `isDotcomRendering` double check if that logic is still required i.e. DCR is gradually taking over the rendering of more features so it's worth checking if any conditional platform checks are still required.
 
 ## Foundational Work
 

--- a/docs/migration/migration.md
+++ b/docs/migration/migration.md
@@ -1,0 +1,35 @@
+# Migration
+
+This document details requirements for moving code from Frontend to commercial-core.
+
+## Entrance Requirements
+
+- Side-effect free code whereever possible
+- Split logic where required to keep code side-effect free
+- TypeScript
+- Unit tested
+- Where we check `isDotcomRendering` double check if that logic is still required i.e. DCR is gradually taking over the rendering of more features so its worth checking if any conditional platform checks are still required.
+
+## Foundational Work
+
+### Config
+
+Create a separate config area on window.guardian e.g.:
+
+`window.guardian.config.commercial`
+
+All code in commercial-core should aim to use this new path.
+
+### Lib functions
+
+Copy small lib functions over to commercial-core.
+
+Once copied decide whether an equivalent exists in `@guardian/libs` version. If it doesn't exist create it in `@guardian/libs`.
+
+Larger, more complex lib functions we could invert control by passing as a dependency from Frontend into a creation function within commercial-core.
+
+# Desirable Patterns
+
+- exports at the end of the file i.e. no inline exports
+- no exports just for testing
+- kebab-case


### PR DESCRIPTION
Co-authored-by: Chris Jones <christopher.jones@guardian.co.uk>

## What does this change?

Document to detail our plan to migrate code from Frontend to commercial-core.

## Why?

To migrate out of an increasingly legacy platform.
