### PR TITLE
chore: Exports at bottom of files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,11 +5,15 @@
     "browser": true,
     "node": true
   },
-  "extends": ["@guardian/eslint-config-typescript"],
+  "extends": [
+    "@guardian/eslint-config-typescript",
+    "plugin:import/recommended"
+  ],
   "globals": { "googletag": "readonly" },
   "ignorePatterns": ["dist", "coverage", "src/__vendor"],
   "rules": {
     "curly": ["error", "multi-line"],
-    "no-use-before-define": ["error", { "functions": true, "classes": true }]
+    "no-use-before-define": ["error", { "functions": true, "classes": true }],
+    "import/exports-last": "error"
   }
 }

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -1,12 +1,12 @@
-export type AdSizeString = 'fluid' | `${number},${number}`;
+type AdSizeString = 'fluid' | `${number},${number}`;
 
-export type AdSize = Readonly<{
+type AdSize = Readonly<{
 	width: number;
 	height: number;
 	toString: () => AdSizeString;
 }>;
 
-export type SizeKeys =
+type SizeKeys =
 	| '160x600'
 	| '300x1050'
 	| '300x250'
@@ -71,7 +71,7 @@ const adSizesPartial = {
 	outstreamMobile: createAdSize(300, 197),
 };
 
-export const adSizes: Record<SizeKeys, AdSize> = {
+const adSizes: Record<SizeKeys, AdSize> = {
 	...adSizesPartial,
 	'970x250': adSizesPartial.billboard,
 	'728x90': adSizesPartial.leaderboard,
@@ -81,7 +81,10 @@ export const adSizes: Record<SizeKeys, AdSize> = {
 	'160x600': adSizesPartial.skyscraper,
 };
 
-export const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
+const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
 
 // Export for testing
 export const _ = { createAdSize };
+
+export type { AdSizeString, AdSize, SizeKeys };
+export { adSizes, getAdSize };

--- a/src/permutive.ts
+++ b/src/permutive.ts
@@ -22,11 +22,10 @@ const getSegments = (key: string): string[] => {
 	}
 };
 
-export const getPermutiveSegments = (): string[] => getSegments(PERMUTIVE_KEY);
-export const getPermutivePFPSegments = (): string[] =>
-	getSegments(PERMUTIVE_PFP_KEY);
+const getPermutiveSegments = (): string[] => getSegments(PERMUTIVE_KEY);
+const getPermutivePFPSegments = (): string[] => getSegments(PERMUTIVE_PFP_KEY);
 
-export const clearPermutiveSegments = (): void => {
+const clearPermutiveSegments = (): void => {
 	storage.local.remove(PERMUTIVE_KEY);
 	storage.local.remove(PERMUTIVE_PFP_KEY);
 };
@@ -35,4 +34,10 @@ export const _ = {
 	PERMUTIVE_KEY,
 	PERMUTIVE_PFP_KEY,
 	getSegments,
+};
+
+export {
+	getPermutiveSegments,
+	getPermutivePFPSegments,
+	clearPermutiveSegments,
 };

--- a/src/send-commercial-metrics.ts
+++ b/src/send-commercial-metrics.ts
@@ -159,7 +159,7 @@ const addVisibilityListeners = (): void => {
 /**
  * A method to asynchronously send metrics after initialization.
  */
-export function bypassCommercialMetricsSampling(): void {
+function bypassCommercialMetricsSampling(): void {
 	if (!initialised) {
 		console.warn('initCommercialMetrics not yet initialised');
 		return;
@@ -184,7 +184,7 @@ interface InitCommercialMetricsArgs {
  * @param init.adBlockerInUse - indicates whether or not an adblocker is being used.
  * @param init.sampling - rate at which to sample commercial metrics - the default is to send for 1% of pageviews
  */
-export function initCommercialMetrics({
+function initCommercialMetrics({
 	pageViewId,
 	browserId,
 	isDev,
@@ -235,3 +235,4 @@ export const _ = {
 };
 
 export type { Property, TimedEvent, Metric };
+export { bypassCommercialMetricsSampling, initCommercialMetrics };

--- a/src/targeting/content.ts
+++ b/src/targeting/content.ts
@@ -29,7 +29,7 @@ const videoLengths = [
  * - a surge in page views per minute
  *
  */
-export type ContentTargeting = {
+type ContentTargeting = {
 	/**
 	 * **D**ot**c**om-**r**endering **E**ligible - [see on Ad Manager][gam]
 	 *
@@ -108,7 +108,7 @@ type Content = {
 	videoLength?: number;
 };
 
-export const getContentTargeting = ({
+const getContentTargeting = ({
 	eligibleForDCR,
 	path,
 	renderingPlatform,
@@ -125,3 +125,6 @@ export const getContentTargeting = ({
 		vl: videoLength ? getVideoLength(videoLength) : null,
 	};
 };
+
+export { getContentTargeting };
+export type { ContentTargeting };

--- a/src/targeting/personalised.ts
+++ b/src/targeting/personalised.ts
@@ -46,7 +46,7 @@ type AdManagerGroup = typeof adManagerGroups[number];
  * It allows or prevents personalised advertising, restrict data processing
  * and handles access to cookies and local storage
  */
-export type PersonalisedTargeting = {
+type PersonalisedTargeting = {
 	/**
 	 * **A**d **M**anager **T**argeting **Gr**ou**p** – [see on Ad Manager][gam]
 	 *
@@ -253,3 +253,4 @@ const getPersonalisedTargeting = (
 });
 
 export { getPersonalisedTargeting };
+export type { PersonalisedTargeting };

--- a/src/targeting/session.ts
+++ b/src/targeting/session.ts
@@ -32,7 +32,7 @@ const referrers = [
  * These values identify a browser session are either generated client-side,
  * read from a cookie or passed down from the server.
  */
-export type SessionTargeting = {
+type SessionTargeting = {
 	/**
 	 * **AB** Tests – [see on Ad Manager][gam]
 	 *
@@ -106,7 +106,7 @@ export type SessionTargeting = {
 	si: True | False;
 };
 
-export type AllParticipations = {
+type AllParticipations = {
 	clientSideParticipations: Participations;
 	serverSideParticipations: {
 		[key: `${string}Control`]: 'control';
@@ -167,7 +167,7 @@ type Session = {
 	referrer: string;
 };
 
-export const getSessionTargeting = ({
+const getSessionTargeting = ({
 	adTest,
 	countryCode,
 	isSignedIn,
@@ -182,3 +182,6 @@ export const getSessionTargeting = ({
 	ref: getReferrer(referrer),
 	si: isSignedIn ? 't' : 'f',
 });
+
+export type { SessionTargeting, AllParticipations };
+export { getSessionTargeting };

--- a/src/targeting/shared.ts
+++ b/src/targeting/shared.ts
@@ -52,7 +52,7 @@ const surges = {
  *
  *
  */
-export type SharedTargeting = {
+type SharedTargeting = {
 	/**
 	 * **Bl**og tags – [see on Ad Manager][gam]
 	 *
@@ -179,10 +179,13 @@ const getSurgingParam = (surging: number): SharedTargeting['su'] => {
 /**
  * What goes in comes out
  */
-export const getSharedTargeting = (
+const getSharedTargeting = (
 	shared: Partial<SharedTargeting>,
 ): Partial<SharedTargeting> => pickTargetingValues(shared);
 
 export const _ = {
 	getSurgingParam,
 };
+
+export type { SharedTargeting };
+export { getSharedTargeting };

--- a/src/targeting/viewport.ts
+++ b/src/targeting/viewport.ts
@@ -10,7 +10,7 @@ import type { False, True } from '../types';
  * - whether a CMP banner will show
  * - size of page skin
  */
-export type ViewportTargeting = {
+type ViewportTargeting = {
 	/**
 	 * **B**reak**p**oint – [see on Ad Manager][gam]
 	 *
@@ -60,7 +60,7 @@ type Viewport = {
 	cmpBannerWillShow: boolean;
 };
 
-export const getViewportTargeting = ({
+const getViewportTargeting = ({
 	viewPortWidth,
 	cmpBannerWillShow,
 }: Viewport): ViewportTargeting => {
@@ -73,3 +73,6 @@ export const getViewportTargeting = ({
 		inskin,
 	};
 };
+
+export type { ViewportTargeting };
+export { getViewportTargeting };

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,8 @@ export type AdsConfig = AdsConfigEnabled | AdsConfigDisabled;
 
 export type AdTargetingBuilder = () => Promise<AdsConfig>;
 
-type True = 't';
-type False = 'f';
-type NotApplicable = 'na';
-export type { True, False, NotApplicable };
+export type True = 't';
+
+export type False = 'f';
+
+export type NotApplicable = 'na';


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Introduce a new Eslint rule [`import/exports-last`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/exports-last.md) which enforces that all exports must be declared at the bottom of the file. Fix all occurrences where this isn't the case.

## Why?

As part of a new [migration strategy](https://github.com/guardian/commercial-core/pull/530), we'd like to standardise on how we manage file exports. This rule ensures all exports are at the bottom of the file, making it easy where to check which values are exported.

We enforce this with an Eslint rule in order to automate checks for this.

## Note on the rule

Note that this rule only forces that all exports must occur at the bottom of the file, and that you can still use named exports, so long as they appear at the end. Hence the following would be valid under this new rule:

```typescript
const a = 10;

export type A = 'hello';

export const foo = () => {
  // ...
}
``` 

```typescript
const a = 10;

export const foo = () => {
  // ...
}

export const bar = () => {
  // ...
}
```

Although this isn't enforced we typically group exports at the bottom of files, like so:

```typescript
const a = 10;

const foo = () => {
  // ...
}

const bar = () => {
  // ...
}

export { foo, bar };
```

There are exceptions to this such as [types.ts](https://github.com/guardian/commercial-core/blob/2c5ab42f816e1bb9ebd2396ff27a9faf3936892a/src/types.ts), since we export every value anyway it makes less sense to export them all again at the bottom.