### PR TITLE
feat: Get consent before sending commercial metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 	"@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
     "@guardian/ab-core": "^2.0.0",
-    "@guardian/consent-management-platform": "^10.1.0",
+    "@guardian/consent-management-platform": "^10.5.0",
     "@guardian/eslint-config-typescript": "^1.0.0",
     "@guardian/libs": "3.6.1",
     "@guardian/prettier": "^0.7.0",

--- a/src/ad-targeting-youtube.spec.ts
+++ b/src/ad-targeting-youtube.spec.ts
@@ -23,7 +23,9 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				ccpa: {
 					doNotSell: false, // *
 				},
-			},
+				canTarget: true,
+				framework: 'ccpa',
+			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
 			custParams: {
@@ -49,7 +51,9 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				ccpa: {
 					doNotSell: true, // *
 				},
-			},
+				canTarget: false,
+				framework: 'ccpa',
+			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
 			custParams: {
@@ -75,7 +79,9 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				ccpa: {
 					doNotSell: false,
 				},
-			} as unknown as ConsentState,
+				canTarget: true,
+				framework: 'ccpa',
+			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
 			custParams: {
@@ -101,7 +107,9 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				ccpa: {
 					doNotSell: false,
 				},
-			},
+				canTarget: true,
+				framework: 'ccpa',
+			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
 			custParams: {
@@ -127,7 +135,9 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				aus: {
 					personalisedAdvertising: true, // *
 				},
-			},
+				canTarget: true,
+				framework: 'aus',
+			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
 			custParams: {
@@ -153,7 +163,9 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				aus: {
 					personalisedAdvertising: false, // *
 				},
-			},
+				canTarget: false,
+				framework: 'aus',
+			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
 			custParams: {
@@ -182,6 +194,8 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 					gdprApplies: true,
 					tcString: 'someTcString',
 				},
+				canTarget: true,
+				framework: 'tcfv2',
 			} as unknown as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
@@ -214,6 +228,8 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 					gdprApplies: true,
 					tcString: 'someTcString',
 				},
+				canTarget: false,
+				framework: 'tcfv2',
 			} as unknown as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
@@ -246,6 +262,8 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 					gdprApplies: false, // *
 					tcString: 'someTcString',
 				},
+				canTarget: true,
+				framework: 'tcfv2',
 			} as unknown as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
@@ -300,7 +318,10 @@ describe('YouTube Ad Targeting Object when consent errors', () => {
 			false,
 			'someAdUnit',
 			{},
-			{},
+			{
+				framework: null,
+				canTarget: false,
+			},
 		);
 		expect(adsConfig).toEqual({ disableAds: true });
 	});
@@ -308,7 +329,15 @@ describe('YouTube Ad Targeting Object when consent errors', () => {
 
 describe('YouTube Ad Targeting Object when ad free user', () => {
 	test('creates disabled ads config when ad free user', () => {
-		const adsConfig = buildAdsConfigWithConsent(true, 'someAdUnit', {}, {});
+		const adsConfig = buildAdsConfigWithConsent(
+			true,
+			'someAdUnit',
+			{},
+			{
+				framework: null,
+				canTarget: false,
+			},
+		);
 		expect(adsConfig).toEqual({ disableAds: true });
 	});
 });

--- a/src/send-commercial-metrics.spec.ts
+++ b/src/send-commercial-metrics.spec.ts
@@ -4,7 +4,6 @@ import {
 	bypassCommercialMetricsSampling,
 	initCommercialMetrics,
 } from './send-commercial-metrics';
-import type { Metric, Property, TimedEvent } from './send-commercial-metrics';
 
 const {
 	Endpoints,
@@ -288,66 +287,64 @@ describe('send commercial metrics code', () => {
 });
 
 describe('send commercial metrics helpers', () => {
-	const eventProperties = {
-		type: undefined,
-		downlink: 1,
-		effectiveType: '4g',
-	};
-
-	const transformedProperties: Array<[string, string | number | undefined]> =
-		[
+	it('can transform event timer properties into object entries', () => {
+		expect(
+			transformToObjectEntries({
+				type: undefined,
+				downlink: 1,
+				effectiveType: '4g',
+			}),
+		).toEqual([
 			['type', undefined],
 			['downlink', 1],
 			['effectiveType', '4g'],
-		];
-
-	const filteredProperties: Array<[string, string | number]> = [
-		['downlink', 1],
-		['effectiveType', '4g'],
-	];
-	const mappedProperties: Property[] = [
-		{
-			name: 'downlink',
-			value: '1',
-		},
-		{
-			name: 'effectiveType',
-			value: '4g',
-		},
-	];
-	const roundedEvent: Metric[] = [
-		{
-			name: 'cmp-tcfv2-init',
-			value: 1519211809935,
-		},
-	];
-
-	it('can transform event timer properties into object entries', () => {
-		const transformed: Array<[string, string | number | undefined]> =
-			transformToObjectEntries(eventProperties);
-		expect(transformed).toEqual(transformedProperties);
+		]);
 	});
 
 	it('can filter out event timer properties with a value that is undefined', () => {
-		const filtered: Array<[string, string | number | undefined]> =
-			filterUndefinedProperties(transformedProperties);
-		expect(filtered).toEqual(filteredProperties);
+		expect(
+			filterUndefinedProperties([
+				['type', undefined],
+				['downlink', 1],
+				['effectiveType', '4g'],
+			]),
+		).toEqual([
+			['downlink', 1],
+			['effectiveType', '4g'],
+		]);
 	});
 
 	it('can map event timer properties to the required format', () => {
-		const mapped = mapEventTimerPropertiesToString(filteredProperties);
-		expect(mapped).toEqual(mappedProperties);
+		expect(
+			mapEventTimerPropertiesToString([
+				['downlink', 1],
+				['effectiveType', '4g'],
+			]),
+		).toEqual([
+			{
+				name: 'downlink',
+				value: '1',
+			},
+			{
+				name: 'effectiveType',
+				value: '4g',
+			},
+		]);
 	});
 
-	// This one is seemingly not doing anything as the start and end values match
 	it('can round up the value of timestamps', () => {
-		const event: TimedEvent[] = [
+		expect(
+			roundTimeStamp([
+				{
+					name: 'cmp-tcfv2-init',
+					ts: 1519211809934.234,
+				},
+			]),
+		).toEqual([
 			{
 				name: 'cmp-tcfv2-init',
-				ts: 1519211809934.234,
+				value: 1519211809935,
 			},
-		];
-		const rounded = roundTimeStamp(event);
-		expect(rounded).toEqual(roundedEvent);
+		]);
 	});
 });

--- a/src/send-commercial-metrics.spec.ts
+++ b/src/send-commercial-metrics.spec.ts
@@ -42,6 +42,10 @@ const setVisibility = (value: 'hidden' | 'visible'): void => {
 	});
 };
 
+beforeEach(() => {
+	reset();
+});
+
 describe('send commercial metrics code', () => {
 	const sendBeacon = jest.fn().mockReturnValue(true);
 	Object.defineProperty(navigator, 'sendBeacon', {
@@ -87,6 +91,13 @@ describe('send commercial metrics code', () => {
 
 	describe('bypassCommercialMetricsSampling', () => {
 		it('sends a beacon if bypassed asynchronously', () => {
+			initCommercialMetrics({
+				pageViewId: PAGE_VIEW_ID,
+				browserId: BROWSER_ID,
+				isDev: IS_NOT_DEV,
+				adBlockerInUse: ADBLOCK_NOT_IN_USE,
+				sampling: USER_NOT_IN_SAMPLING,
+			});
 			bypassCommercialMetricsSampling();
 
 			setVisibility('hidden');
@@ -96,7 +107,6 @@ describe('send commercial metrics code', () => {
 			]);
 		});
 		it('expects to be initialised before calling bypassCoreWebVitalsSampling', () => {
-			reset();
 			bypassCommercialMetricsSampling();
 			expect(mockConsoleWarn).toHaveBeenCalledWith(
 				'initCommercialMetrics not yet initialised',
@@ -105,10 +115,6 @@ describe('send commercial metrics code', () => {
 	});
 
 	describe('handles various configurations', () => {
-		beforeEach(() => {
-			reset();
-		});
-
 		afterEach(() => {
 			// Reset the properties of the event timer for the purposes of this test
 			delete window.guardian.commercialTimer;

--- a/src/send-commercial-metrics.spec.ts
+++ b/src/send-commercial-metrics.spec.ts
@@ -45,7 +45,7 @@ const mockSendMetrics = () =>
 		sampling: USER_IN_SAMPLING,
 	});
 
-const setVisibility = (value: 'hidden' | 'visible' = 'hidden'): void => {
+const setVisibility = (value: 'hidden' | 'visible'): void => {
 	Object.defineProperty(document, 'visibilityState', {
 		value,
 		writable: true,
@@ -67,7 +67,7 @@ describe('send commercial metrics code', () => {
 
 	it('can send commercial metrics when the page is hidden', () => {
 		const metricsSent = mockSendMetrics();
-		setVisibility();
+		setVisibility('hidden');
 		global.dispatchEvent(new Event('visibilitychange'));
 
 		expect(metricsSent).toEqual(true);
@@ -89,7 +89,7 @@ describe('send commercial metrics code', () => {
 		it('sends a beacon if bypassed asynchronously', () => {
 			bypassCommercialMetricsSampling();
 
-			setVisibility();
+			setVisibility('hidden');
 			global.dispatchEvent(new Event('visibilitychange'));
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 				[Endpoints.PROD, JSON.stringify(defaultMetrics)],
@@ -123,7 +123,7 @@ describe('send commercial metrics code', () => {
 				adBlockerInUse: ADBLOCK_NOT_IN_USE,
 				sampling: USER_IN_SAMPLING,
 			});
-			setVisibility();
+			setVisibility('hidden');
 			global.dispatchEvent(new Event('visibilitychange'));
 
 			expect(mockSendMetrics).toEqual(true);
@@ -149,7 +149,7 @@ describe('send commercial metrics code', () => {
 				downlink: 1,
 				effectiveType: '4g',
 			};
-			setVisibility();
+			setVisibility('hidden');
 			global.dispatchEvent(new Event('visibilitychange'));
 
 			expect(sentMetrics).toEqual(true);
@@ -182,7 +182,7 @@ describe('send commercial metrics code', () => {
 				adBlockerInUse: ADBLOCK_NOT_IN_USE,
 				sampling: USER_IN_SAMPLING,
 			});
-			setVisibility();
+			setVisibility('hidden');
 			global.dispatchEvent(new Event('pagehide'));
 			expect(sentMetrics).toEqual(true);
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
@@ -237,7 +237,7 @@ describe('send commercial metrics code', () => {
 				adBlockerInUse: undefined,
 				sampling: USER_IN_SAMPLING,
 			});
-			setVisibility();
+			setVisibility('hidden');
 			global.dispatchEvent(new Event('pagehide'));
 			expect(sentMetrics).toEqual(true);
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
@@ -261,7 +261,7 @@ describe('send commercial metrics code', () => {
 				browserId: BROWSER_ID,
 				isDev: IS_DEV,
 			});
-			setVisibility();
+			setVisibility('hidden');
 			const eventTimer = EventTimer.get();
 			eventTimer.setProperty('adSlotsInline', 5);
 			eventTimer.setProperty('adSlotsTotal', 10);

--- a/src/send-commercial-metrics.spec.ts
+++ b/src/send-commercial-metrics.spec.ts
@@ -36,15 +36,6 @@ const defaultMetrics = {
 	],
 };
 
-const mockSendMetrics = () =>
-	initCommercialMetrics({
-		pageViewId: PAGE_VIEW_ID,
-		browserId: BROWSER_ID,
-		isDev: IS_NOT_DEV,
-		adBlockerInUse: ADBLOCK_NOT_IN_USE,
-		sampling: USER_IN_SAMPLING,
-	});
-
 const setVisibility = (value: 'hidden' | 'visible'): void => {
 	Object.defineProperty(document, 'visibilityState', {
 		value,
@@ -66,22 +57,32 @@ describe('send commercial metrics code', () => {
 		.mockImplementation(() => false);
 
 	it('can send commercial metrics when the page is hidden', () => {
-		const metricsSent = mockSendMetrics();
+		initCommercialMetrics({
+			pageViewId: PAGE_VIEW_ID,
+			browserId: BROWSER_ID,
+			isDev: IS_NOT_DEV,
+			adBlockerInUse: ADBLOCK_NOT_IN_USE,
+			sampling: USER_IN_SAMPLING,
+		});
 		setVisibility('hidden');
 		global.dispatchEvent(new Event('visibilitychange'));
 
-		expect(metricsSent).toEqual(true);
 		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 			[Endpoints.PROD, JSON.stringify(defaultMetrics)],
 		]);
 	});
 
 	it('commercial metrics not sent when window is visible', () => {
-		const metricsSent = mockSendMetrics();
+		initCommercialMetrics({
+			pageViewId: PAGE_VIEW_ID,
+			browserId: BROWSER_ID,
+			isDev: IS_NOT_DEV,
+			adBlockerInUse: ADBLOCK_NOT_IN_USE,
+			sampling: USER_IN_SAMPLING,
+		});
 		setVisibility('visible');
 		global.dispatchEvent(new Event('visibilitychange'));
 
-		expect(metricsSent).toEqual(false);
 		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([]);
 	});
 
@@ -116,7 +117,7 @@ describe('send commercial metrics code', () => {
 		});
 
 		it('should handle endpoint in dev', () => {
-			const mockSendMetrics = initCommercialMetrics({
+			initCommercialMetrics({
 				pageViewId: PAGE_VIEW_ID,
 				browserId: BROWSER_ID,
 				isDev: IS_DEV,
@@ -126,7 +127,6 @@ describe('send commercial metrics code', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('visibilitychange'));
 
-			expect(mockSendMetrics).toEqual(true);
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.CODE,
@@ -142,7 +142,13 @@ describe('send commercial metrics code', () => {
 		});
 
 		it('should handle connection properties if they exist', () => {
-			const sentMetrics = mockSendMetrics();
+			initCommercialMetrics({
+				pageViewId: PAGE_VIEW_ID,
+				browserId: BROWSER_ID,
+				isDev: IS_NOT_DEV,
+				adBlockerInUse: ADBLOCK_NOT_IN_USE,
+				sampling: USER_IN_SAMPLING,
+			});
 			const eventTimer = EventTimer.get();
 			// Fix the properties of the event timer for the purposes of this test
 			eventTimer.properties = {
@@ -152,7 +158,6 @@ describe('send commercial metrics code', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('visibilitychange'));
 
-			expect(sentMetrics).toEqual(true);
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.PROD,
@@ -175,7 +180,7 @@ describe('send commercial metrics code', () => {
 				downlink: 1,
 				effectiveType: '4g',
 			};
-			const sentMetrics = initCommercialMetrics({
+			initCommercialMetrics({
 				pageViewId: PAGE_VIEW_ID,
 				browserId: BROWSER_ID,
 				isDev: IS_DEV,
@@ -184,7 +189,6 @@ describe('send commercial metrics code', () => {
 			});
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('pagehide'));
-			expect(sentMetrics).toEqual(true);
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.CODE,
@@ -230,7 +234,7 @@ describe('send commercial metrics code', () => {
 				downlink: 1,
 				effectiveType: '4g',
 			};
-			const sentMetrics = initCommercialMetrics({
+			initCommercialMetrics({
 				pageViewId: PAGE_VIEW_ID,
 				browserId: BROWSER_ID,
 				isDev: IS_DEV,
@@ -239,7 +243,6 @@ describe('send commercial metrics code', () => {
 			});
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('pagehide'));
-			expect(sentMetrics).toEqual(true);
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.CODE,
@@ -256,7 +259,7 @@ describe('send commercial metrics code', () => {
 		});
 
 		it('should handle ad slot properties', () => {
-			const sentMetrics = initCommercialMetrics({
+			initCommercialMetrics({
 				pageViewId: PAGE_VIEW_ID,
 				browserId: BROWSER_ID,
 				isDev: IS_DEV,
@@ -266,7 +269,6 @@ describe('send commercial metrics code', () => {
 			eventTimer.setProperty('adSlotsInline', 5);
 			eventTimer.setProperty('adSlotsTotal', 10);
 			global.dispatchEvent(new Event('pagehide'));
-			expect(sentMetrics).toEqual(true);
 			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.CODE,

--- a/src/send-commercial-metrics.spec.ts
+++ b/src/send-commercial-metrics.spec.ts
@@ -206,26 +206,27 @@ describe('send commercial metrics code', () => {
 		});
 
 		it('should return false if user is not in sampling', () => {
-			const sentMetrics = initCommercialMetrics({
+			const willSendMetrics = initCommercialMetrics({
 				pageViewId: PAGE_VIEW_ID,
 				browserId: BROWSER_ID,
 				isDev: IS_NOT_DEV,
 				adBlockerInUse: ADBLOCK_NOT_IN_USE,
 				sampling: USER_NOT_IN_SAMPLING,
 			});
-			expect(sentMetrics).toEqual(false);
+			expect(willSendMetrics).toEqual(false);
 		});
 
 		it('should set sampling at 0.01 if sampling is not passed in', () => {
-			const sentMetrics = initCommercialMetrics({
+			const willSendMetrics = initCommercialMetrics({
 				pageViewId: PAGE_VIEW_ID,
 				browserId: BROWSER_ID,
 				isDev: IS_NOT_DEV,
 				adBlockerInUse: ADBLOCK_NOT_IN_USE,
 			});
+
 			const mathRandomSpy = jest.spyOn(Math, 'random');
 			mathRandomSpy.mockImplementation(() => 0.5);
-			expect(sentMetrics).toEqual(false);
+			expect(willSendMetrics).toEqual(false);
 		});
 
 		it('should merge properties even if adblocking is not passed in', () => {

--- a/src/send-commercial-metrics.spec.ts
+++ b/src/send-commercial-metrics.spec.ts
@@ -9,7 +9,6 @@ import {
 
 const {
 	Endpoints,
-	filterUndefinedProperties,
 	mapEventTimerPropertiesToString,
 	reset,
 	roundTimeStamp,
@@ -520,19 +519,6 @@ describe('send commercial metrics helpers', () => {
 			}),
 		).toEqual([
 			['type', undefined],
-			['downlink', 1],
-			['effectiveType', '4g'],
-		]);
-	});
-
-	it('can filter out event timer properties with a value that is undefined', () => {
-		expect(
-			filterUndefinedProperties([
-				['type', undefined],
-				['downlink', 1],
-				['effectiveType', '4g'],
-			]),
-		).toEqual([
 			['downlink', 1],
 			['effectiveType', '4g'],
 		]);

--- a/src/send-commercial-metrics.ts
+++ b/src/send-commercial-metrics.ts
@@ -75,15 +75,18 @@ const transformToObjectEntries = (
 	return Object.entries(eventTimerProperties);
 };
 
-const filterUndefinedProperties = <T>(
-	transformedProperties: Array<[string, T | undefined]>,
-): Array<[string, T]> =>
-	transformedProperties.reduce<Array<[string, T]>>((acc, [key, value]) => {
-		if (typeof value !== 'undefined') {
-			acc.push([key, value]);
-		}
-		return acc;
-	}, []);
+const filterUndefinedProperties = (
+	transformedProperties: Array<[string, string | number | undefined]>,
+): Array<[string, string | number]> =>
+	transformedProperties.reduce<Array<[string, string | number]>>(
+		(acc, [key, value]) => {
+			if (typeof value !== 'undefined') {
+				acc.push([key, value]);
+			}
+			return acc;
+		},
+		[],
+	);
 
 const mapEventTimerPropertiesToString = (
 	properties: Array<[string, string | number]>,

--- a/src/send-commercial-metrics.ts
+++ b/src/send-commercial-metrics.ts
@@ -77,19 +77,6 @@ const transformToObjectEntries = (
 	return Object.entries(eventTimerProperties);
 };
 
-const filterUndefinedProperties = (
-	transformedProperties: Array<[string, string | number | undefined]>,
-): Array<[string, string | number]> =>
-	transformedProperties.reduce<Array<[string, string | number]>>(
-		(acc, [key, value]) => {
-			if (typeof value !== 'undefined') {
-				acc.push([key, value]);
-			}
-			return acc;
-		},
-		[],
-	);
-
 const mapEventTimerPropertiesToString = (
 	properties: Array<[string, string | number]>,
 ): Property[] => {
@@ -119,12 +106,15 @@ function sendMetrics() {
 	);
 }
 
+type ArrayMetric = [key: string, value: string | number];
+
 function gatherMetricsOnPageUnload(): void {
 	// Assemble commercial properties and metrics
 	const eventTimer = EventTimer.get();
 	const transformedEntries = transformToObjectEntries(eventTimer.properties);
-	const filteredEventTimerProperties =
-		filterUndefinedProperties(transformedEntries);
+	const filteredEventTimerProperties = transformedEntries.filter<ArrayMetric>(
+		(item): item is ArrayMetric => typeof item[1] !== 'undefined',
+	);
 	const mappedEventTimerProperties = mapEventTimerPropertiesToString(
 		filteredEventTimerProperties,
 	);
@@ -250,7 +240,6 @@ async function initCommercialMetrics({
 export const _ = {
 	Endpoints,
 	setEndpoint,
-	filterUndefinedProperties,
 	mapEventTimerPropertiesToString,
 	roundTimeStamp,
 	transformToObjectEntries,

--- a/src/targeting/personalised.spec.ts
+++ b/src/targeting/personalised.spec.ts
@@ -21,6 +21,8 @@ describe('Personalised targeting', () => {
 					gdprApplies: true,
 					tcString: 'I<3IAB.tcf.ftw',
 				},
+				canTarget: true,
+				framework: 'tcfv2',
 			};
 
 			storage.local.setRaw(FREQUENCY_KEY, '1');
@@ -49,6 +51,8 @@ describe('Personalised targeting', () => {
 					gdprApplies: true,
 					tcString: 'I<3IAB.tcf.ftw',
 				},
+				canTarget: false,
+				framework: 'tcfv2',
 			};
 
 			const expected: Partial<PersonalisedTargeting> = {
@@ -66,6 +70,8 @@ describe('Personalised targeting', () => {
 		it('Full Consent', () => {
 			const state: ConsentState = {
 				ccpa: { doNotSell: false },
+				canTarget: true,
+				framework: 'ccpa',
 			};
 
 			storage.local.setRaw(FREQUENCY_KEY, '4');
@@ -83,6 +89,8 @@ describe('Personalised targeting', () => {
 		it('Do Not Sell', () => {
 			const state: ConsentState = {
 				ccpa: { doNotSell: true },
+				canTarget: false,
+				framework: 'ccpa',
 			};
 
 			storage.local.setRaw(FREQUENCY_KEY, '4');
@@ -102,6 +110,8 @@ describe('Personalised targeting', () => {
 		test('Full Consent', () => {
 			const state: ConsentState = {
 				aus: { personalisedAdvertising: true },
+				canTarget: true,
+				framework: 'aus',
 			};
 
 			storage.local.setRaw(FREQUENCY_KEY, '12');
@@ -119,6 +129,8 @@ describe('Personalised targeting', () => {
 		test('Personalised Advertising OFF', () => {
 			const state: ConsentState = {
 				aus: { personalisedAdvertising: false },
+				canTarget: false,
+				framework: 'aus',
 			};
 
 			storage.local.setRaw(FREQUENCY_KEY, '12');
@@ -162,6 +174,8 @@ describe('Personalised targeting', () => {
 		test.each(frequencies)('Should get `%s` for %f', (fr, val) => {
 			const state: ConsentState = {
 				ccpa: { doNotSell: false },
+				canTarget: true,
+				framework: 'ccpa',
 			};
 
 			storage.local.setRaw(FREQUENCY_KEY, String(val));
@@ -198,6 +212,8 @@ describe('Personalised targeting', () => {
 		test.each(groups)('Should get `%s` if it exists', (amtgrp, val) => {
 			const state: ConsentState = {
 				ccpa: { doNotSell: false },
+				canTarget: true,
+				framework: 'ccpa',
 			};
 
 			storage.local.remove(AMTGRP_STORAGE_KEY);
@@ -220,7 +236,10 @@ describe('Personalised targeting', () => {
 
 	describe('Unknown', () => {
 		test('Not Applicable', () => {
-			const state: ConsentState = {};
+			const state: ConsentState = {
+				canTarget: false,
+				framework: null,
+			};
 
 			const expected: PersonalisedTargeting = {
 				amtgrp: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,10 +474,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
   integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
 
-"@guardian/consent-management-platform@^10.1.0":
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.2.2.tgz#bffa22192c68b308574d6c6abfb22277058d3e32"
-  integrity sha512-lLdVTrDhxtf9BC3S2PNLMJf7/cR0Zo5RnfstWaynGerwOILwM8Ppl5xdHX/i6RdZrt2O4Z7GuB6mxhNAeAw27A==
+"@guardian/consent-management-platform@^10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.5.0.tgz#5195abd5cf6d940dbdfb7c27b05165913999ed0e"
+  integrity sha512-oxCcHLalyMMIMneolgX7d/n5NM+e7cVYhPwITmYdw2dyM6zpmsZsUENEVnno49HpU0MamD7YzNrhE4HT2w2YIA==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 


### PR DESCRIPTION
## What does this change?

When in TCFv2 mode, check the user has consented to purpose 7 (measure ad performance) and 8 (measure content performance) of the TCF framework before sending commercial metrics to the server.

When in non-TCFv2 mode, no need to check anything.

Also makes some improvements to `send-commercial-metrics.spec.ts` which are easiest reviewed commit-by-commit. Some of these are down to taste and I'm definitely happy to be challenged if these go against any testing principles I'm not aware of!

## Why?

We shouldn't be collecting metrics without consent