### PR TITLE
chore: Replace git.io links with resolved links

### DIFF
--- a/src/detect-ad-blocker.ts
+++ b/src/detect-ad-blocker.ts
@@ -1,7 +1,8 @@
 /**
 Detect whether or not the user has an ad blocking extension enabled.
 A few ad blockers are not detectable with this approach e.g. Safari / Adblock
-Code inspired by just-detect-adblock's: https://git.io/JgL4L
+Code inspired by just-detect-adblock's:
+https://github.com/wmcmurray/just-detect-adblock/blob/master/src/helpers.js
 */
 /*istanbul ignore file -- adElementBlocked can't be tested without patching each of the properties of
 HTMLElement.prototype that it accesses, defeating the purpose of the test! */

--- a/src/targeting/shared.ts
+++ b/src/targeting/shared.ts
@@ -45,9 +45,11 @@ const surges = {
 } as const;
 
 /**
- * Shared Targeting is passed by `frontend` https://git.io/JDJ6W
+ * Shared Targeting is passed by `frontend`:
+ * https://github.com/guardian/frontend/blob/5b970cd7308175cfc1bcae2d4fb8c06ee13c5fa0/common/app/common/commercial/EditionAdTargeting.scala
  *
- * It is generated in `commercial-shared` https://git.io/JDJ62
+ * It is generated in `commercial-shared`:
+ * https://github.com/guardian/commercial-shared/blob/a692e8b2eba6e79eeeb666e5594f2193663f6514/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
  *
  *
  *


### PR DESCRIPTION
Co-authored-by: Max Duval <max.duval@theguardian.com>

## What does this change?

Replace git.io links with resolved links as git.io will be deprecated on 2022-04-29:

https://github.blog/changelog/2022-04-25-git-io-deprecation

Used @mxdvl 's guide:

https://gist.github.com/mxdvl/eae14de45152bfec04c9d7c9786ad997
