### PR TITLE
feat: Collect commercial metrics on GPC signal

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^17.0.0",
     "@guardian/ab-core": "^2.0.0",
-    "@guardian/consent-management-platform": "^10.5.0",
+    "@guardian/consent-management-platform": "guardian/consent-management-platform#notice-gpc-navigator",
     "@guardian/eslint-config-typescript": "^1.0.0",
     "@guardian/libs": "5.1.0",
     "@guardian/prettier": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^17.0.0",
     "@guardian/ab-core": "^2.0.0",
-    "@guardian/consent-management-platform": "guardian/consent-management-platform#notice-gpc-navigator",
+    "@guardian/consent-management-platform": "^10.6.0",
     "@guardian/eslint-config-typescript": "^1.0.0",
     "@guardian/libs": "5.1.0",
     "@guardian/prettier": "^1.0.0",

--- a/src/event-timer.ts
+++ b/src/event-timer.ts
@@ -41,6 +41,7 @@ interface EventTimerProperties {
 	adSlotsTotal?: number;
 	// the height of the page / the viewport height
 	pageHeightVH?: number;
+	gpcSignal?: number;
 	// distance in percentage of viewport height at which ads are lazy loaded
 	lazyLoadMarginPercent?: number;
 }
@@ -188,6 +189,7 @@ export class EventTimer {
 			| 'adSlotsInline'
 			| 'adSlotsTotal'
 			| 'pageHeightVH'
+			| 'gpcSignal'
 			| 'lazyLoadMarginPercent',
 		value: number,
 	): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
 	getPermutivePFPSegments,
 } from './permutive';
 export { initTrackScrollDepth } from './track-scroll-depth';
+export { initTrackGpcSignal } from './track-gpc-signal';
 export { buildAdsConfigWithConsent, disabledAds } from './ad-targeting-youtube';
 export type {
 	AdsConfig,

--- a/src/track-gpc-signal.spec.ts
+++ b/src/track-gpc-signal.spec.ts
@@ -1,0 +1,55 @@
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { EventTimer } from './event-timer';
+import { initTrackGpcSignal } from './track-gpc-signal';
+
+describe('initTrackGpcSignal', () => {
+	test('tracks an undefined gpcSignal on ConsentState', () => {
+		const eventTimer = EventTimer.get();
+
+		const consentState: ConsentState = {
+			ccpa: {
+				doNotSell: false, // *
+			},
+			canTarget: true,
+			framework: 'ccpa',
+		};
+
+		initTrackGpcSignal(consentState);
+
+		expect(eventTimer.properties['gpcSignal']).toEqual(-1);
+	});
+
+	test('tracks a false gpcSignal on ConsentState', () => {
+		const eventTimer = EventTimer.get();
+
+		const consentState: ConsentState = {
+			ccpa: {
+				doNotSell: false, // *
+			},
+			canTarget: true,
+			framework: 'ccpa',
+			gpcSignal: false,
+		};
+
+		initTrackGpcSignal(consentState);
+
+		expect(eventTimer.properties['gpcSignal']).toEqual(0);
+	});
+
+	test('tracks a true gpcSignal on ConsentState', () => {
+		const eventTimer = EventTimer.get();
+
+		const consentState: ConsentState = {
+			ccpa: {
+				doNotSell: false, // *
+			},
+			canTarget: true,
+			framework: 'ccpa',
+			gpcSignal: true,
+		};
+
+		initTrackGpcSignal(consentState);
+
+		expect(eventTimer.properties['gpcSignal']).toEqual(1);
+	});
+});

--- a/src/track-gpc-signal.spec.ts
+++ b/src/track-gpc-signal.spec.ts
@@ -8,7 +8,7 @@ describe('initTrackGpcSignal', () => {
 
 		const consentState: ConsentState = {
 			ccpa: {
-				doNotSell: false, // *
+				doNotSell: false,
 			},
 			canTarget: true,
 			framework: 'ccpa',
@@ -24,7 +24,7 @@ describe('initTrackGpcSignal', () => {
 
 		const consentState: ConsentState = {
 			ccpa: {
-				doNotSell: false, // *
+				doNotSell: false,
 			},
 			canTarget: true,
 			framework: 'ccpa',
@@ -41,7 +41,7 @@ describe('initTrackGpcSignal', () => {
 
 		const consentState: ConsentState = {
 			ccpa: {
-				doNotSell: false, // *
+				doNotSell: false,
 			},
 			canTarget: true,
 			framework: 'ccpa',

--- a/src/track-gpc-signal.ts
+++ b/src/track-gpc-signal.ts
@@ -1,0 +1,21 @@
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { log } from '@guardian/libs';
+import { EventTimer } from './event-timer';
+
+/**
+ * Collect metrics on gpcSignal presence and value
+ * https://globalprivacycontrol.github.io/gpc-spec/
+ */
+const initTrackGpcSignal = (consentState: ConsentState) => {
+	// If undefined we set the property value to -1, false is 0, true is 1
+	const gpcSignal =
+		consentState.gpcSignal === undefined ? -1 : +consentState.gpcSignal;
+
+	const eventTimer = EventTimer.get();
+
+	log('commercial', `gpcSignal ${gpcSignal}`);
+
+	eventTimer.setProperty('gpcSignal', gpcSignal);
+};
+
+export { initTrackGpcSignal };

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,10 +480,9 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
   integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
 
-"@guardian/consent-management-platform@^10.5.0":
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.5.0.tgz#5195abd5cf6d940dbdfb7c27b05165913999ed0e"
-  integrity sha512-oxCcHLalyMMIMneolgX7d/n5NM+e7cVYhPwITmYdw2dyM6zpmsZsUENEVnno49HpU0MamD7YzNrhE4HT2w2YIA==
+"@guardian/consent-management-platform@guardian/consent-management-platform#notice-gpc-navigator":
+  version "0.0.0-this-never-updates-in-source-code-refer-to-git-tags"
+  resolved "https://codeload.github.com/guardian/consent-management-platform/tar.gz/76077688e4c08f7f37e80f5628f116ac89d818fa"
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,9 +480,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
   integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
 
-"@guardian/consent-management-platform@guardian/consent-management-platform#notice-gpc-navigator":
-  version "0.0.0-this-never-updates-in-source-code-refer-to-git-tags"
-  resolved "https://codeload.github.com/guardian/consent-management-platform/tar.gz/76077688e4c08f7f37e80f5628f116ac89d818fa"
+"@guardian/consent-management-platform@^10.6.0":
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.6.0.tgz#18b13a1b6eebc2dcf0d708d12bcd6b93a2c407a3"
+  integrity sha512-U4JvXWV/gG5WwNsooVncYQSf5nroEinVnq2nCIrinQeMyhn6M2syxNnQVqIk/CE05Mh84OpR/ZWvGoz30b2/wA==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 


### PR DESCRIPTION
## What does this change?

Adds a function `initTrackGpcSignal` which collects metrics on the [GPC signal](https://globalprivacycontrol.org/#gpc-spec) when handed a `ConsentState` from the [guardian/consent-management-platform](https://github.com/guardian/consent-management-platform) library. 

## Why?

We'd like to understand the commercial impact of the GPC signal on our platform and track any changes over time.

Depends on https://github.com/guardian/consent-management-platform/pull/606