### PR TITLE
feat: Migrate create-ad-slot.ts

### DIFF
--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -40,7 +40,7 @@ interface SizeMapping {
 	tablet?: AdSize[];
 }
 
-interface SizeMappings {
+interface SlotSizeMappings {
 	right: SizeMapping;
 	comments: SizeMapping;
 	'top-above-nav': SizeMapping;
@@ -98,7 +98,7 @@ const adSizes: Record<SizeKeys, AdSize> = {
 	'160x600': adSizesPartial.skyscraper,
 };
 
-const sizeMappings: SizeMappings = {
+const slotSizeMappings: SlotSizeMappings = {
 	right: {
 		mobile: [
 			adSizes.outOfPage,
@@ -217,5 +217,5 @@ const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
 // Export for testing
 export const _ = { createAdSize };
 
-export type { AdSizeString, AdSize, SizeKeys };
-export { adSizes, getAdSize, sizeMappings };
+export type { AdSizeString, AdSize, SizeKeys, SizeMapping };
+export { adSizes, getAdSize, slotSizeMappings };

--- a/src/create-ad-slot.spec.ts
+++ b/src/create-ad-slot.spec.ts
@@ -1,0 +1,105 @@
+import { adSizes } from './ad-sizes';
+import { createAdSlot } from './create-ad-slot';
+
+const imHtml = `
+<div id="dfp-ad--im"
+    class="js-ad-slot ad-slot ad-slot--im"
+    data-link-name="ad slot im"
+    data-name="im"
+    aria-hidden="true"
+    data-mobile="1,1|2,2|88,85|fluid"
+    data-label="false"
+    data-refresh="false"></div>
+`;
+
+const inline1Html = `
+<div id="dfp-ad--inline1"
+    class="js-ad-slot ad-slot ad-slot--inline ad-slot--inline1"
+    data-link-name="ad slot inline1"
+    data-name="inline1"
+    aria-hidden="true"
+    data-mobile="1,1|2,2|300,197|300,250|300,274|fluid"
+    data-phablet="1,1|2,2|300,197|300,250|300,274|fluid|620,350|550,310"
+    data-desktop="1,1|2,2|300,250|300,274|fluid|620,350|550,310">
+</div>
+`;
+
+describe('Create Ad Slot', () => {
+	beforeEach(() => {
+		window.guardian = {
+			config: {
+				isDotcomRendering: true,
+			},
+		};
+	});
+	it('should exist', () => {
+		expect(createAdSlot).toBeDefined();
+	});
+
+	it.each([
+		{
+			type: 'im' as const,
+			htmls: imHtml,
+			name: undefined,
+			classes: undefined,
+			sizes: undefined,
+		},
+		{
+			type: 'inline' as const,
+			classes: 'inline',
+			name: 'inline1',
+			htmls: inline1Html,
+			sizes: {
+				desktop: [
+					adSizes.outstreamDesktop,
+					adSizes.outstreamGoogleDesktop,
+				],
+				phablet: [
+					adSizes.outstreamDesktop,
+					adSizes.outstreamGoogleDesktop,
+				],
+			},
+		},
+	])(
+		`should create $type ad slot`,
+		({ type, name, classes, sizes, htmls }) => {
+			const adSlot = createAdSlot(type, {
+				name,
+				classes,
+				sizes,
+			});
+
+			expect(adSlot.outerHTML).toBe(
+				htmls.replace(/\n/g, '').replace(/\s+/g, ' '),
+			);
+		},
+	);
+
+	it('should create "inline1" ad slot and merge valid additional sizes', () => {
+		const adSlot = createAdSlot('inline', {
+			sizes: {
+				desktop: [
+					adSizes.outstreamDesktop,
+					adSizes.outstreamGoogleDesktop,
+				],
+				mobile: [adSizes.inlineMerchandising],
+				invalid: [adSizes.leaderboard],
+			},
+		});
+		const desktopSizes = adSlot.getAttribute('data-desktop');
+		expect(desktopSizes).toEqual(
+			'1,1|2,2|300,250|300,274|fluid|620,350|550,310',
+		);
+		const mobileSizes = adSlot.getAttribute('data-mobile');
+		expect(mobileSizes).toEqual(
+			'1,1|2,2|300,197|300,250|300,274|fluid|88,85',
+		);
+		expect(adSlot.getAttributeNames()).not.toContain('data-invalid');
+	});
+
+	it('should use correct sizes for the mobile top-above-nav slot', () => {
+		const topAboveNavSlot = createAdSlot('top-above-nav');
+		const mobileSizes = topAboveNavSlot.getAttribute('data-mobile');
+		expect(mobileSizes).toBe('1,1|2,2|88,71|300,197|300,250|fluid');
+	});
+});

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -1,0 +1,311 @@
+import type { AdSize, SizeMapping } from './ad-sizes';
+import { adSizes } from './ad-sizes';
+
+const adSlotIdPrefix = 'dfp-ad--';
+
+type AdSlotConfig = {
+	sizeMappings: SizeMapping;
+	label?: boolean;
+	refresh?: boolean;
+	name?: string;
+};
+
+type SlotName =
+	| 'im'
+	| 'high-merch'
+	| 'high-merch-lucky'
+	| 'high-merch-paid'
+	| 'inline'
+	| 'mostpop'
+	| 'comments'
+	| 'top-above-nav'
+	| 'carrot'
+	| 'epic'
+	| 'mobile-sticky';
+
+type AdSlotConfigs = Record<SlotName, AdSlotConfig>;
+
+type CreateSlotOptions = {
+	classes?: string;
+	name?: string;
+	sizes?: Record<string, AdSize[] | undefined>; // allow an empty object
+};
+
+const commonSizeMappings: SizeMapping = {
+	mobile: [
+		adSizes.outOfPage,
+		adSizes.empty,
+		adSizes.outstreamMobile,
+		adSizes.mpu,
+		adSizes.googleCard,
+		adSizes.fluid,
+	],
+	phablet: [
+		adSizes.outOfPage,
+		adSizes.empty,
+		adSizes.outstreamMobile,
+		adSizes.mpu,
+		adSizes.googleCard,
+		adSizes.fluid,
+	],
+	desktop: [
+		adSizes.outOfPage,
+		adSizes.empty,
+		adSizes.mpu,
+		adSizes.googleCard,
+		adSizes.fluid,
+	],
+};
+
+/*
+
+    mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
+
+    The ad sizes which are hardcoded here are also hardcoded in the source code of
+    dotcom-rendering.
+
+    If/when this file is modified, please make sure that updates, if any, are reported to DCR.
+
+	TODO use a map type??
+	want to assert that values are of type AdSlotConfig
+ */
+
+const adSlotConfigs: AdSlotConfigs = {
+	im: {
+		label: false,
+		refresh: false,
+		sizeMappings: {
+			mobile: [
+				adSizes.outOfPage,
+				adSizes.empty,
+				adSizes.inlineMerchandising,
+				adSizes.fluid,
+			],
+		},
+	},
+	'high-merch': {
+		label: false,
+		refresh: false,
+		name: 'merchandising-high',
+		sizeMappings: {
+			mobile: [
+				adSizes.outOfPage,
+				adSizes.empty,
+				adSizes.merchandisingHigh,
+				adSizes.fluid,
+			],
+		},
+	},
+	'high-merch-lucky': {
+		label: false,
+		refresh: false,
+		name: 'merchandising-high-lucky',
+		sizeMappings: {
+			mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid],
+		},
+	},
+	'high-merch-paid': {
+		label: false,
+		refresh: false,
+		name: 'merchandising-high',
+		sizeMappings: {
+			mobile: [
+				adSizes.outOfPage,
+				adSizes.empty,
+				adSizes.merchandisingHighAdFeature,
+				adSizes.fluid,
+			],
+		},
+	},
+	inline: {
+		sizeMappings: commonSizeMappings,
+	},
+	mostpop: {
+		sizeMappings: commonSizeMappings,
+	},
+	comments: {
+		sizeMappings: commonSizeMappings,
+	},
+	'top-above-nav': {
+		sizeMappings: {
+			mobile: [
+				adSizes.outOfPage,
+				adSizes.empty,
+				adSizes.fabric,
+				adSizes.outstreamMobile,
+				adSizes.mpu,
+				adSizes.fluid,
+			],
+		},
+	},
+	carrot: {
+		label: false,
+		refresh: false,
+		name: 'carrot',
+		sizeMappings: {
+			mobile: [adSizes.fluid],
+		},
+	},
+	epic: {
+		label: false,
+		refresh: false,
+		name: 'epic',
+		sizeMappings: {
+			mobile: [adSizes.fluid],
+		},
+	},
+	'mobile-sticky': {
+		label: true,
+		refresh: true,
+		name: 'mobile-sticky',
+		sizeMappings: {
+			mobile: [adSizes.mobilesticky],
+		},
+	},
+};
+
+/*
+  Returns an adSlot HTMLElement which is the main DFP slot.
+
+  Insert that element as siblings at the place you want adverts to appear.
+
+  Note that for the DFP slot to be filled by GTP, you'll have to
+  use addSlot from add-slot.js
+*/
+const createAdSlotElement = (
+	name: string,
+	attrs: Record<string, string>,
+	classes: string[],
+): HTMLElement => {
+	const id = `${adSlotIdPrefix}${name}`;
+
+	// 3562dc07-78e9-4507-b922-78b979d4c5cb
+	if (window.guardian.config.isDotcomRendering && name === 'top-above-nav') {
+		// This is to prevent a problem that appeared with DCR.
+		// We are simply making sure that if we are about to
+		// introduce dfp-ad--top-above-nav then there isn't already one.
+		const node = document.getElementById(id);
+		if (node?.parentNode) {
+			const pnode = node.parentNode;
+			console.log(`warning: cleaning up dom node id: dfp-ad--${name}`);
+			pnode.removeChild(node);
+		}
+	}
+
+	// The 'main' adSlot
+	const adSlot = document.createElement('div');
+	adSlot.id = id;
+	adSlot.className = `js-ad-slot ad-slot ${classes.join(' ')}`;
+	adSlot.setAttribute('data-link-name', `ad slot ${name}`);
+	adSlot.setAttribute('data-name', name);
+	adSlot.setAttribute('aria-hidden', 'true');
+	Object.entries(attrs).forEach(([k, v]) => adSlot.setAttribute(k, v));
+
+	return adSlot;
+};
+
+/**
+ * Split class names and prefix all with ad-slot--${className}
+ */
+const createClasses = (
+	slotName: string,
+	classes?: string,
+): Array<`ad-slot--${string}`> =>
+	[...(classes?.split(' ') ?? []), slotName].map<`ad-slot--${string}`>(
+		(className: string) => `ad-slot--${className}`,
+	);
+
+/**
+ * Given default size mappings and additional size mappings from
+ * the createAdSlot options parameter.
+ *
+ * 1. Check that the options size mappings use known device names
+ * 2. If so concat the size mappings
+ *
+ */
+const concatSizeMappings = (
+	defaultSizeMappings: SizeMapping,
+	optionSizeMappings: CreateSlotOptions['sizes'],
+): SizeMapping => {
+	if (!optionSizeMappings) return defaultSizeMappings;
+	const concatenatedSizeMappings: SizeMapping = { ...defaultSizeMappings };
+	const optionDevices = Object.keys(optionSizeMappings); // ['mobile', 'desktop']
+
+	for (let i = 0; i < optionDevices.length; i++) {
+		const device = optionDevices[i] as keyof SizeMapping;
+		if (optionSizeMappings[device] && defaultSizeMappings[device]) {
+			const optionSizeMappingsForDevice = optionSizeMappings[device];
+			const defaultSizeMappingsForDevice = defaultSizeMappings[device];
+
+			if (defaultSizeMappingsForDevice && optionSizeMappingsForDevice) {
+				// TODO can we do concatenatedSizeMappings[device]?.concat ?
+				concatenatedSizeMappings[device] = (
+					concatenatedSizeMappings[device] ?? []
+				).concat(optionSizeMappingsForDevice);
+			}
+		}
+	}
+	return concatenatedSizeMappings;
+};
+
+/**
+ * Convert size mappings to a string that will be added to the ad slot
+ * data attributes.
+ *
+ * e.g. { desktop: [[320,250], [320, 280]] } => { desktop: '320,250|320,280' }
+ *
+ */
+const covertSizeMappingsToStrings = (
+	sizeMappings: SizeMapping,
+): Record<string, string> =>
+	Object.entries(sizeMappings).reduce(
+		(result: Record<string, string>, [device, sizes]) => {
+			// TODO remove assertion
+			result[device] = (sizes as AdSize[]).join('|');
+			return result;
+		},
+		{},
+	);
+
+/**
+ * Prefix all object keys with data-${key}
+ */
+const createDataAttributes = (
+	attrs: Record<string, string>,
+): Record<`data-${string}`, string> =>
+	Object.entries(attrs).reduce(
+		(result: Record<string, string>, [key, value]) => {
+			result[`data-${key}`] = value;
+			return result;
+		},
+		{},
+	);
+
+export const createAdSlot = (
+	name: SlotName,
+	options: CreateSlotOptions = {},
+): HTMLElement => {
+	const adSlotConfig = adSlotConfigs[name];
+	const slotName = options.name ?? adSlotConfig.name ?? name;
+
+	const sizeMappings = concatSizeMappings(
+		adSlotConfig.sizeMappings,
+		options.sizes,
+	);
+
+	const attributes = covertSizeMappingsToStrings(sizeMappings);
+
+	if (adSlotConfig.label === false) {
+		attributes.label = 'false';
+	}
+
+	if (adSlotConfig.refresh === false) {
+		attributes.refresh = 'false';
+	}
+
+	return createAdSlotElement(
+		slotName,
+		createDataAttributes(attributes),
+		createClasses(slotName, options.classes),
+	);
+};

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -164,7 +164,7 @@ const adSlotConfigs: AdSlotConfigs = {
 	},
 };
 
-/*
+/**
   Returns an adSlot HTMLElement which is the main DFP slot.
 
   Insert that element as siblings at the place you want adverts to appear.

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -28,7 +28,7 @@ type AdSlotConfigs = Record<SlotName, AdSlotConfig>;
 type CreateSlotOptions = {
 	classes?: string;
 	name?: string;
-	sizes?: Record<string, AdSize[] | undefined>; // allow an empty object
+	sizes?: Record<string, AdSize[]>;
 };
 
 const commonSizeMappings: SizeMapping = {

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -259,9 +259,8 @@ const covertSizeMappingsToStrings = (
 	sizeMappings: SizeMapping,
 ): Record<string, string> =>
 	Object.entries(sizeMappings).reduce(
-		(result: Record<string, string>, [device, sizes]) => {
-			// TODO remove assertion
-			result[device] = (sizes as AdSize[]).join('|');
+		(result: Record<string, string>, [device, sizes]: [string, AdSize[]]) => {
+			result[device] =sizes.join('|');
 			return result;
 		},
 		{},

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -180,7 +180,7 @@ const createAdSlotElement = (
 	const id = `${adSlotIdPrefix}${name}`;
 
 	// 3562dc07-78e9-4507-b922-78b979d4c5cb
-	if (window.guardian.config.isDotcomRendering && name === 'top-above-nav') {
+	if (window.guardian.config?.isDotcomRendering && name === 'top-above-nav') {
 		// This is to prevent a problem that appeared with DCR.
 		// We are simply making sure that if we are about to
 		// introduce dfp-ad--top-above-nav then there isn't already one.

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -259,8 +259,11 @@ const covertSizeMappingsToStrings = (
 	sizeMappings: SizeMapping,
 ): Record<string, string> =>
 	Object.entries(sizeMappings).reduce(
-		(result: Record<string, string>, [device, sizes]: [string, AdSize[]]) => {
-			result[device] =sizes.join('|');
+		(
+			result: Record<string, string>,
+			[device, sizes]: [string, AdSize[]],
+		) => {
+			result[device] = sizes.join('|');
 			return result;
 		},
 		{},

--- a/src/global.ts
+++ b/src/global.ts
@@ -20,7 +20,7 @@ declare global {
 		}>;
 		guardian: {
 			commercialTimer?: EventTimer;
-			config: GuardianWindowConfig;
+			config?: GuardianWindowConfig;
 		};
 		ga: UniversalAnalytics.ga | null;
 		readonly navigator: Navigator;

--- a/src/global.ts
+++ b/src/global.ts
@@ -20,7 +20,7 @@ declare global {
 		}>;
 		guardian: {
 			commercialTimer?: EventTimer;
-			config?: GuardianWindowConfig;
+			config: GuardianWindowConfig;
 		};
 		ga: UniversalAnalytics.ga | null;
 		readonly navigator: Navigator;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export {
 	initCommercialMetrics,
 } from './send-commercial-metrics';
 export type { ThirdPartyTag } from './types';
-export { adSizes, getAdSize, sizeMappings } from './ad-sizes';
+export { adSizes, getAdSize, slotSizeMappings } from './ad-sizes';
 export type { SizeKeys, AdSizeString, AdSize } from './ad-sizes';
 export { isAdBlockInUse } from './detect-ad-blocker';
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type GuardianAnalyticsConfig = {
 
 export type GuardianWindowConfig = {
 	googleAnalytics?: GuardianAnalyticsConfig;
+	isDotcomRendering: boolean;
 };
 
 export type GoogleTagParams = unknown;

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export type GuardianAnalyticsConfig = {
 
 export type GuardianWindowConfig = {
 	googleAnalytics?: GuardianAnalyticsConfig;
-	isDotcomRendering: boolean;
+	isDotcomRendering?: boolean;
 };
 
 export type GoogleTagParams = unknown;


### PR DESCRIPTION
## What does this change?
Migrate create-ad-slot.ts and it's test to commerical-core

## Why?
