### PR TITLE
feat: Copy frontend size mappings into ad-sizes

### DIFF
--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -74,7 +74,16 @@ type SlotName =
 	| 'mostpop'
 	| 'merchandising'
 	| 'merchandising-high'
-	| 'survey';
+	| 'merchandising-high-lucky'
+	| 'survey'
+	| 'im'
+	| 'inline'
+	| 'mostpop'
+	| 'comments'
+	| 'top-above-nav'
+	| 'carrot'
+	| 'epic'
+	| 'mobile-sticky';
 
 type Breakpoint = 'mobile' | 'desktop' | 'phablet' | 'tablet';
 
@@ -129,6 +138,31 @@ const adSizes: Record<SizeKeys, AdSize> = {
  * these were originally from DCR, create-ad-slot.ts ones were in frontend.
  **/
 const slotSizeMappings: SlotSizeMappings = {
+	inline: {
+		mobile: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.outstreamMobile,
+			adSizes.mpu,
+			adSizes.googleCard,
+			adSizes.fluid,
+		],
+		phablet: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.outstreamMobile,
+			adSizes.mpu,
+			adSizes.googleCard,
+			adSizes.fluid,
+		],
+		desktop: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.mpu,
+			adSizes.googleCard,
+			adSizes.fluid,
+		],
+	},
 	right: {
 		mobile: [
 			adSizes.outOfPage,
@@ -168,6 +202,14 @@ const slotSizeMappings: SlotSizeMappings = {
 		],
 	},
 	'top-above-nav': {
+		mobile: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.fabric,
+			adSizes.outstreamMobile,
+			adSizes.mpu,
+			adSizes.fluid,
+		],
 		tablet: [
 			adSizes.outOfPage,
 			adSizes.empty,
@@ -221,6 +263,14 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.fluid,
 		],
 	},
+	im: {
+		mobile: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.inlineMerchandising,
+			adSizes.fluid,
+		],
+	},
 	'merchandising-high': {
 		mobile: [
 			adSizes.outOfPage,
@@ -228,6 +278,9 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.merchandisingHigh,
 			adSizes.fluid,
 		],
+	},
+	'merchandising-high-lucky': {
+		mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid],
 	},
 	merchandising: {
 		mobile: [
@@ -239,6 +292,15 @@ const slotSizeMappings: SlotSizeMappings = {
 	},
 	survey: {
 		desktop: [adSizes.outOfPage],
+	},
+	carrot: {
+		mobile: [adSizes.fluid],
+	},
+	epic: {
+		mobile: [adSizes.fluid],
+	},
+	'mobile-sticky': {
+		mobile: [adSizes.mobilesticky],
 	},
 };
 

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -1,5 +1,5 @@
 import type { AdSize, SizeMapping } from './ad-sizes';
-import { adSizes } from './ad-sizes';
+import { slotSizeMappings } from './ad-sizes';
 
 const adSlotIdPrefix = 'dfp-ad--';
 
@@ -31,129 +31,59 @@ type CreateSlotOptions = {
 	sizes?: Record<string, AdSize[]>;
 };
 
-const commonSizeMappings: SizeMapping = {
-	mobile: [
-		adSizes.outOfPage,
-		adSizes.empty,
-		adSizes.outstreamMobile,
-		adSizes.mpu,
-		adSizes.googleCard,
-		adSizes.fluid,
-	],
-	phablet: [
-		adSizes.outOfPage,
-		adSizes.empty,
-		adSizes.outstreamMobile,
-		adSizes.mpu,
-		adSizes.googleCard,
-		adSizes.fluid,
-	],
-	desktop: [
-		adSizes.outOfPage,
-		adSizes.empty,
-		adSizes.mpu,
-		adSizes.googleCard,
-		adSizes.fluid,
-	],
-};
-
-/**
- * mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
- * Some of these may or may not need to be synced for with the sizes in ./ad-sizes.ts
- * these were originally from frontend, ad-sizes.ts ones were in DCR.
- **/
-
 const adSlotConfigs: AdSlotConfigs = {
 	im: {
 		label: false,
 		refresh: false,
-		sizeMappings: {
-			mobile: [
-				adSizes.outOfPage,
-				adSizes.empty,
-				adSizes.inlineMerchandising,
-				adSizes.fluid,
-			],
-		},
+		sizeMappings: slotSizeMappings['im'],
 	},
 	'high-merch': {
 		label: false,
 		refresh: false,
 		name: 'merchandising-high',
-		sizeMappings: {
-			mobile: [
-				adSizes.outOfPage,
-				adSizes.empty,
-				adSizes.merchandisingHigh,
-				adSizes.fluid,
-			],
-		},
+		sizeMappings: slotSizeMappings['merchandising-high'],
 	},
 	'high-merch-lucky': {
 		label: false,
 		refresh: false,
 		name: 'merchandising-high-lucky',
-		sizeMappings: {
-			mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid],
-		},
+		sizeMappings: slotSizeMappings['merchandising-high-lucky'],
 	},
 	'high-merch-paid': {
 		label: false,
 		refresh: false,
 		name: 'merchandising-high',
-		sizeMappings: {
-			mobile: [
-				adSizes.outOfPage,
-				adSizes.empty,
-				adSizes.merchandisingHighAdFeature,
-				adSizes.fluid,
-			],
-		},
+		sizeMappings: slotSizeMappings['merchandising-high'],
 	},
 	inline: {
-		sizeMappings: commonSizeMappings,
+		sizeMappings: slotSizeMappings['inline'],
 	},
 	mostpop: {
-		sizeMappings: commonSizeMappings,
+		sizeMappings: slotSizeMappings['mostpop'],
 	},
 	comments: {
-		sizeMappings: commonSizeMappings,
+		sizeMappings: slotSizeMappings['comments'],
 	},
 	'top-above-nav': {
-		sizeMappings: {
-			mobile: [
-				adSizes.outOfPage,
-				adSizes.empty,
-				adSizes.fabric,
-				adSizes.outstreamMobile,
-				adSizes.mpu,
-				adSizes.fluid,
-			],
-		},
+		sizeMappings: slotSizeMappings['top-above-nav'],
 	},
 	carrot: {
 		label: false,
 		refresh: false,
 		name: 'carrot',
-		sizeMappings: {
-			mobile: [adSizes.fluid],
-		},
+		sizeMappings: slotSizeMappings['merchandising-high'],
 	},
 	epic: {
 		label: false,
 		refresh: false,
 		name: 'epic',
-		sizeMappings: {
-			mobile: [adSizes.fluid],
-		},
+		sizeMappings: slotSizeMappings['epic'],
 	},
 	'mobile-sticky': {
 		label: true,
 		refresh: true,
 		name: 'mobile-sticky',
-		sizeMappings: {
-			mobile: [adSizes.mobilesticky],
-		},
+		sizeMappings: slotSizeMappings['mobile-sticky'],
 	},
 };
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Copy frontend size mappings into ad-sizes

## Why?
Sorry, yet another PR on ad sizes

Didn't do this initially because of the clash with the 'top-above-nav' name, but have noticed it's actually safe to do as frontend only uses the `mobile` size in the browser and dotcom the rest

This is needed in order to lookup the ad sizes in frontend, they _could_ be kept in separate objects but unnecessary I think and would require different object names etc.
