### PR TITLE
fix: Only send commercial metrics once

### DIFF
--- a/src/send-commercial-metrics.ts
+++ b/src/send-commercial-metrics.ts
@@ -145,10 +145,10 @@ const listener = (e: Event): void => {
 
 const addVisibilityListeners = (): void => {
 	// Report all available metrics when the page is unloaded or in background.
-	window.addEventListener('visibilitychange', listener);
+	window.addEventListener('visibilitychange', listener, { once: true });
 
 	// Safari does not reliably fire the `visibilitychange` on page unload.
-	window.addEventListener('pagehide', listener);
+	window.addEventListener('pagehide', listener, { once: true });
 };
 
 const checkConsent = async (): Promise<boolean> => {


### PR DESCRIPTION
## What does this change?

Send commercial metrics a maximum of one time for each pageview.

## Why?

@ashishpuliyel has a hypothesis that some of the outliers in the timing data is related to browsers that suspend the window, and then resume (tabs put into the background and resumed the next day for example).

The timers become somewhat meaningless once the tab has been put into the background, so we should stop the timers after that.