### PR TITLE
feat: Add logic for setting Ad Manager group cookie

### DIFF
--- a/src/targeting/personalised.spec.ts
+++ b/src/targeting/personalised.spec.ts
@@ -232,14 +232,55 @@ describe('Personalised targeting', () => {
 
 			mockRandom.mockRestore();
 		});
+
+		test('Ad manager group IS NOT set if TCFv2 and consent not given', () => {
+			const state: ConsentState = {
+				tcfv2: {
+					consents: {},
+				},
+				canTarget: false,
+				framework: 'tcfv2',
+			} as ConsentState;
+
+			storage.local.set(AMTGRP_STORAGE_KEY, '1');
+
+			const targeting = getPersonalisedTargeting(state);
+
+			expect(targeting.amtgrp).toBeNull();
+			expect(storage.local.get(AMTGRP_STORAGE_KEY)).toBeNull();
+		});
+
+		test('Ad manager group IS set if ccpa and consent not given', () => {
+			const state: ConsentState = {
+				ccpa: { doNotSell: true },
+				canTarget: false,
+				framework: 'ccpa',
+			};
+
+			const targeting = getPersonalisedTargeting(state);
+			expect(targeting.amtgrp).not.toBeNull();
+		});
+
+		test('Ad manager group IS set if aus and consent not given', () => {
+			const state: ConsentState = {
+				aus: { personalisedAdvertising: false },
+				canTarget: false,
+				framework: 'aus',
+			};
+
+			const targeting = getPersonalisedTargeting(state);
+			expect(targeting.amtgrp).not.toBeNull();
+		});
 	});
 
 	describe('Unknown', () => {
-		test('Not Applicable', () => {
+		test('No Framework', () => {
 			const state: ConsentState = {
 				canTarget: false,
 				framework: null,
 			};
+
+			storage.local.set(AMTGRP_STORAGE_KEY, '1');
 
 			const expected: PersonalisedTargeting = {
 				amtgrp: null,
@@ -250,7 +291,9 @@ describe('Personalised targeting', () => {
 				rdp: 'na',
 			};
 			const targeting = getPersonalisedTargeting(state);
+
 			expect(targeting).toMatchObject(expected);
+			expect(storage.local.get(AMTGRP_STORAGE_KEY)).toBeNull();
 		});
 	});
 });

--- a/src/targeting/personalised.ts
+++ b/src/targeting/personalised.ts
@@ -207,7 +207,12 @@ const createAdManagerGroup = (): AdManagerGroup => {
 const getAdManagerGroup = (
 	state: ConsentState,
 ): PersonalisedTargeting['amtgrp'] => {
-	if (!state.canTarget) {
+	if (!state.framework) {
+		storage.local.remove(AMTGRP_STORAGE_KEY);
+		return null;
+	}
+
+	if (state.tcfv2 && !state.canTarget) {
 		storage.local.remove(AMTGRP_STORAGE_KEY);
 		return null;
 	}


### PR DESCRIPTION

<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

- Set cookie `amtgrp` if the user is in CCPA or aus, regardless of the user's consent state. This is because this cookie is not used for targeting/personalisation. It is used for A/B tests.
- Remove superfluous functions: `personalisedAdvertising` and `tcfv2AllPurposesConsented`.

## Why?

- To correct logic whilst migrating commercial code over from frontend to commercial-core.