### PR TITLE
feat: Add crossword banner slot to slot size definitions

### DIFF
--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -83,7 +83,8 @@ type SlotName =
 	| 'top-above-nav'
 	| 'carrot'
 	| 'epic'
-	| 'mobile-sticky';
+	| 'mobile-sticky'
+	| 'crossword-banner';
 
 type Breakpoint = 'mobile' | 'desktop' | 'phablet' | 'tablet';
 
@@ -302,6 +303,18 @@ const slotSizeMappings: SlotSizeMappings = {
 	'mobile-sticky': {
 		mobile: [adSizes.mobilesticky],
 	},
+	'crossword-banner': {
+		tablet: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.leaderboard
+		],
+		phablet: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.leaderboard
+		],
+	}
 };
 
 const getAdSize = (size: SizeKeys): AdSize => adSizes[size];

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -304,17 +304,9 @@ const slotSizeMappings: SlotSizeMappings = {
 		mobile: [adSizes.mobilesticky],
 	},
 	'crossword-banner': {
-		tablet: [
-			adSizes.outOfPage,
-			adSizes.empty,
-			adSizes.leaderboard
-		],
-		phablet: [
-			adSizes.outOfPage,
-			adSizes.empty,
-			adSizes.leaderboard
-		],
-	}
+		tablet: [adSizes.outOfPage, adSizes.empty, adSizes.leaderboard],
+		phablet: [adSizes.outOfPage, adSizes.empty, adSizes.leaderboard],
+	},
 };
 
 const getAdSize = (size: SizeKeys): AdSize => adSizes[size];


### PR DESCRIPTION
## What does this change?

Adding a new slot size mapping for the crossword banner ads that appear on tablet displays.

## Why?

At the moment the crossword banner ad slot is not getting the right sizes of adverts, causing ads to overlap comments on the page. Adding this new size mapping is the first step towards fixing this bug.