### PR TITLE
feat: Refactor and export `concatSizeMappings`

### DIFF
--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -88,6 +88,9 @@ type SlotName =
 
 type Breakpoint = 'mobile' | 'desktop' | 'phablet' | 'tablet';
 
+const isBreakpoint = (s: string): s is Breakpoint =>
+	s === 'mobile' || s === 'phablet' || s === 'tablet' || s === 'desktop';
+
 type SizeMapping = Partial<Record<Breakpoint, AdSize[]>>;
 
 type SlotSizeMappings = Record<SlotName, SizeMapping>;
@@ -322,4 +325,4 @@ export type {
 	SlotSizeMappings,
 	SlotName,
 };
-export { adSizes, getAdSize, slotSizeMappings, createAdSize };
+export { adSizes, getAdSize, slotSizeMappings, createAdSize, isBreakpoint };

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -1,3 +1,5 @@
+import type { Breakpoint } from './lib/breakpoint';
+
 type AdSizeString = 'fluid' | `${number},${number}`;
 
 /**
@@ -85,11 +87,6 @@ type SlotName =
 	| 'epic'
 	| 'mobile-sticky'
 	| 'crossword-banner';
-
-type Breakpoint = 'mobile' | 'desktop' | 'phablet' | 'tablet';
-
-const isBreakpoint = (s: string): s is Breakpoint =>
-	s === 'mobile' || s === 'phablet' || s === 'tablet' || s === 'desktop';
 
 type SizeMapping = Partial<Record<Breakpoint, AdSize[]>>;
 
@@ -325,4 +322,4 @@ export type {
 	SlotSizeMappings,
 	SlotName,
 };
-export { adSizes, getAdSize, slotSizeMappings, createAdSize, isBreakpoint };
+export { adSizes, getAdSize, slotSizeMappings, createAdSize };

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -1,5 +1,6 @@
 import type { AdSize, SizeMapping } from './ad-sizes';
-import { isBreakpoint, slotSizeMappings } from './ad-sizes';
+import { slotSizeMappings } from './ad-sizes';
+import { isBreakpoint } from './lib/breakpoint';
 
 const adSlotIdPrefix = 'dfp-ad--';
 

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -148,9 +148,9 @@ const createClasses = (
  */
 const concatSizeMappings = (
 	defaultSizeMappings: SizeMapping,
-	optionSizeMappings?: SizeMapping,
+	optionSizeMappings: SizeMapping = {},
 ): SizeMapping =>
-	Object.entries(optionSizeMappings ?? {}).reduce<SizeMapping>(
+	Object.entries(optionSizeMappings).reduce<SizeMapping>(
 		(sizeMappings, [breakpoint, optionSizes]) => {
 			// Only perform concatenation if breakpoint is of the correct type
 			if (isBreakpoint(breakpoint)) {

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -1,5 +1,5 @@
 import type { AdSize, SizeMapping } from './ad-sizes';
-import { slotSizeMappings } from './ad-sizes';
+import { isBreakpoint, slotSizeMappings } from './ad-sizes';
 
 const adSlotIdPrefix = 'dfp-ad--';
 
@@ -148,28 +148,21 @@ const createClasses = (
  */
 const concatSizeMappings = (
 	defaultSizeMappings: SizeMapping,
-	optionSizeMappings: CreateSlotOptions['sizes'],
-): SizeMapping => {
-	if (!optionSizeMappings) return defaultSizeMappings;
-	const concatenatedSizeMappings: SizeMapping = { ...defaultSizeMappings };
-	const optionDevices = Object.keys(optionSizeMappings); // ['mobile', 'desktop']
-
-	for (let i = 0; i < optionDevices.length; i++) {
-		const device = optionDevices[i] as keyof SizeMapping;
-		if (optionSizeMappings[device] && defaultSizeMappings[device]) {
-			const optionSizeMappingsForDevice = optionSizeMappings[device];
-			const defaultSizeMappingsForDevice = defaultSizeMappings[device];
-
-			if (defaultSizeMappingsForDevice && optionSizeMappingsForDevice) {
-				// TODO can we do concatenatedSizeMappings[device]?.concat ?
-				concatenatedSizeMappings[device] = (
-					concatenatedSizeMappings[device] ?? []
-				).concat(optionSizeMappingsForDevice);
+	optionSizeMappings?: SizeMapping,
+): SizeMapping =>
+	Object.entries(optionSizeMappings ?? {}).reduce<SizeMapping>(
+		(sizeMappings, [breakpoint, optionSizes]) => {
+			// Only perform concatenation if breakpoint is of the correct type
+			if (isBreakpoint(breakpoint)) {
+				// Concatenate the option sizes onto any existing sizes present for a given breakpoint
+				sizeMappings[breakpoint] = (
+					sizeMappings[breakpoint] ?? []
+				).concat(optionSizes);
 			}
-		}
-	}
-	return concatenatedSizeMappings;
-};
+			return sizeMappings;
+		},
+		{ ...defaultSizeMappings },
+	);
 
 /**
  * Convert size mappings to a string that will be added to the ad slot
@@ -206,7 +199,7 @@ const createDataAttributes = (
 		{},
 	);
 
-export const createAdSlot = (
+const createAdSlot = (
 	name: SlotName,
 	options: CreateSlotOptions = {},
 ): HTMLElement => {
@@ -234,3 +227,5 @@ export const createAdSlot = (
 		createClasses(slotName, options.classes),
 	);
 };
+
+export { createAdSlot, concatSizeMappings };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,13 @@ export {
 	initCommercialMetrics,
 } from './send-commercial-metrics';
 export type { ThirdPartyTag } from './types';
-export { adSizes, getAdSize, slotSizeMappings, createAdSize } from './ad-sizes';
+export {
+	adSizes,
+	getAdSize,
+	slotSizeMappings,
+	createAdSize,
+	isBreakpoint,
+} from './ad-sizes';
 export type {
 	SizeKeys,
 	AdSizeString,
@@ -30,7 +36,7 @@ export {
 export { initTrackScrollDepth } from './track-scroll-depth';
 export { initTrackGpcSignal } from './track-gpc-signal';
 export { buildAdsConfigWithConsent, disabledAds } from './ad-targeting-youtube';
-export { createAdSlot } from './create-ad-slot';
+export { createAdSlot, concatSizeMappings } from './create-ad-slot';
 export type {
 	AdsConfig,
 	AdsConfigBasic,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,9 @@ export {
 	initCommercialMetrics,
 } from './send-commercial-metrics';
 export type { ThirdPartyTag } from './types';
-export {
-	adSizes,
-	getAdSize,
-	slotSizeMappings,
-	createAdSize,
-	isBreakpoint,
-} from './ad-sizes';
+export { adSizes, getAdSize, slotSizeMappings, createAdSize } from './ad-sizes';
+export { isBreakpoint } from './lib/breakpoint';
+export type { Breakpoint } from './lib/breakpoint';
 export type {
 	SizeKeys,
 	AdSizeString,

--- a/src/lib/breakpoint.spec.ts
+++ b/src/lib/breakpoint.spec.ts
@@ -1,0 +1,19 @@
+import { isBreakpoint } from './breakpoint';
+
+describe('isBreakpoint', () => {
+	const cases: Array<[string, boolean]> = [
+		['mobile', true],
+		['phablet', true],
+		['tablet', true],
+		['desktop', true],
+		['foo', false],
+		['wide', false],
+		['leftCol', false],
+	];
+	it.each(cases)(
+		'isBreakpoint(%s) returns %s',
+		(breakpoint, expectedOutput) => {
+			expect(isBreakpoint(breakpoint)).toBe(expectedOutput);
+		},
+	);
+});

--- a/src/lib/breakpoint.ts
+++ b/src/lib/breakpoint.ts
@@ -1,0 +1,7 @@
+type Breakpoint = 'mobile' | 'desktop' | 'phablet' | 'tablet';
+
+const isBreakpoint = (s: string): s is Breakpoint =>
+	s === 'mobile' || s === 'phablet' || s === 'tablet' || s === 'desktop';
+
+export type { Breakpoint };
+export { isBreakpoint };


### PR DESCRIPTION
## What does this change?

Deal with one of our `// TODO` markers by refactoring the `concatSizeMappings` function.

This requires the introduction of an `isBreakpoint` type guard - to ensure we don't concat additional keys in objects. Note that because of the use of `reduce` we won't affect the original size mappings.

## Why?

> TODO