### PR TITLE
feat: createAdSlot no longer adds size mappings data attrs

### DIFF
--- a/src/create-ad-slot.spec.ts
+++ b/src/create-ad-slot.spec.ts
@@ -1,4 +1,3 @@
-import { adSizes } from './ad-sizes';
 import { createAdSlot } from './create-ad-slot';
 
 const imHtml = `
@@ -7,7 +6,6 @@ const imHtml = `
     data-link-name="ad slot im"
     data-name="im"
     aria-hidden="true"
-    data-mobile="1,1|2,2|88,85|fluid"
     data-label="false"
     data-refresh="false"></div>
 `;
@@ -17,10 +15,7 @@ const inline1Html = `
     class="js-ad-slot ad-slot ad-slot--inline ad-slot--inline1"
     data-link-name="ad slot inline1"
     data-name="inline1"
-    aria-hidden="true"
-    data-mobile="1,1|2,2|300,197|300,250|300,274|fluid"
-    data-phablet="1,1|2,2|300,197|300,250|300,274|fluid|620,350|550,310"
-    data-desktop="1,1|2,2|300,250|300,274|fluid|620,350|550,310">
+    aria-hidden="true">
 </div>
 `;
 
@@ -42,64 +37,21 @@ describe('Create Ad Slot', () => {
 			htmls: imHtml,
 			name: undefined,
 			classes: undefined,
-			sizes: undefined,
 		},
 		{
 			type: 'inline' as const,
 			classes: 'inline',
 			name: 'inline1',
 			htmls: inline1Html,
-			sizes: {
-				desktop: [
-					adSizes.outstreamDesktop,
-					adSizes.outstreamGoogleDesktop,
-				],
-				phablet: [
-					adSizes.outstreamDesktop,
-					adSizes.outstreamGoogleDesktop,
-				],
-			},
 		},
-	])(
-		`should create $type ad slot`,
-		({ type, name, classes, sizes, htmls }) => {
-			const adSlot = createAdSlot(type, {
-				name,
-				classes,
-				sizes,
-			});
-
-			expect(adSlot.outerHTML).toBe(
-				htmls.replace(/\n/g, '').replace(/\s+/g, ' '),
-			);
-		},
-	);
-
-	it('should create "inline1" ad slot and merge valid additional sizes', () => {
-		const adSlot = createAdSlot('inline', {
-			sizes: {
-				desktop: [
-					adSizes.outstreamDesktop,
-					adSizes.outstreamGoogleDesktop,
-				],
-				mobile: [adSizes.inlineMerchandising],
-				invalid: [adSizes.leaderboard],
-			},
+	])(`should create $type ad slot`, ({ type, name, classes, htmls }) => {
+		const adSlot = createAdSlot(type, {
+			name,
+			classes,
 		});
-		const desktopSizes = adSlot.getAttribute('data-desktop');
-		expect(desktopSizes).toEqual(
-			'1,1|2,2|300,250|300,274|fluid|620,350|550,310',
-		);
-		const mobileSizes = adSlot.getAttribute('data-mobile');
-		expect(mobileSizes).toEqual(
-			'1,1|2,2|300,197|300,250|300,274|fluid|88,85',
-		);
-		expect(adSlot.getAttributeNames()).not.toContain('data-invalid');
-	});
 
-	it('should use correct sizes for the mobile top-above-nav slot', () => {
-		const topAboveNavSlot = createAdSlot('top-above-nav');
-		const mobileSizes = topAboveNavSlot.getAttribute('data-mobile');
-		expect(mobileSizes).toBe('1,1|2,2|88,71|300,197|300,250|fluid');
+		expect(adSlot.outerHTML).toBe(
+			htmls.replace(/\n/g, '').replace(/\s+/g, ' '),
+		);
 	});
 });


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Removes anything to do with sizeMappings from `createAdSlot`, as they no longer need to be written to the data attributes.

## Why?
They are redundant now, size mappings are now loaded from https://github.com/guardian/commercial-core/blob/main/src/ad-sizes.ts#L143 as of this frontend PR https://github.com/guardian/frontend/pull/25124