### PR TITLE
feat: add new function to return the array of an ad size

### DIFF
--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -1,7 +1,7 @@
-import { _, getAdSize } from './ad-sizes';
+import { _, adSizes, getAdSize } from './ad-sizes';
 import type { SizeKeys } from '.';
 
-const { createAdSize } = _;
+const { createAdSize, getAdSizeArray } = _;
 
 describe('ad sizes', () => {
 	it.each([
@@ -39,4 +39,17 @@ describe('getAdSize', () => {
 			expect(adSize.toString()).toEqual(expectedString);
 		},
 	);
+});
+
+describe('get ad size array', () => {
+	it('should return an array of the AdSize', () => {
+		expect(getAdSizeArray(adSizes.skyscraper)).toEqual([160, 600]);
+	});
+});
+
+describe('ad size splicing', () => {
+	it('should be able to splice the array returned from getAdSizeArray', () => {
+		expect(getAdSizeArray(adSizes.skyscraper).splice(0, 1)[0]).toEqual(160);
+		expect(getAdSizeArray(adSizes.skyscraper).splice(1, 1)[0]).toEqual(600);
+	});
 });

--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -43,14 +43,14 @@ describe('getAdSize', () => {
 
 describe('get ad size array', () => {
 	it('should return an array of the AdSize', () => {
-		expect(adSizes.skyscraper.array).toEqual([160, 600]);
-		expect(adSizes.leaderboard.array.pop()).toEqual(90);
+		expect(adSizes.skyscraper.toArray()).toEqual([160, 600]);
+		expect(adSizes.leaderboard.toArray().pop()).toEqual(90);
 	});
 });
 
 describe('ad size splicing', () => {
 	it('should be able to splice the array returned from the array method on AdSize', () => {
-		expect(adSizes.skyscraper.array.splice(0, 1)[0]).toEqual(160);
-		expect(adSizes.skyscraper.array.splice(1, 1)[0]).toEqual(600);
+		expect(adSizes.skyscraper.toArray().splice(0, 1)[0]).toEqual(160);
+		expect(adSizes.skyscraper.toArray().splice(1, 1)[0]).toEqual(600);
 	});
 });

--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -44,6 +44,7 @@ describe('getAdSize', () => {
 describe('get ad size array', () => {
 	it('should return an array of the AdSize', () => {
 		expect(getAdSizeArray(adSizes.skyscraper)).toEqual([160, 600]);
+		expect(getAdSizeArray(adSizes.leaderboard).pop()).toEqual(90);
 	});
 });
 

--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -1,7 +1,7 @@
 import { _, adSizes, getAdSize } from './ad-sizes';
 import type { SizeKeys } from '.';
 
-const { createAdSize, getAdSizeArray } = _;
+const { createAdSize } = _;
 
 describe('ad sizes', () => {
 	it.each([
@@ -43,14 +43,14 @@ describe('getAdSize', () => {
 
 describe('get ad size array', () => {
 	it('should return an array of the AdSize', () => {
-		expect(getAdSizeArray(adSizes.skyscraper)).toEqual([160, 600]);
-		expect(getAdSizeArray(adSizes.leaderboard).pop()).toEqual(90);
+		expect(adSizes.skyscraper.array).toEqual([160, 600]);
+		expect(adSizes.leaderboard.array.pop()).toEqual(90);
 	});
 });
 
 describe('ad size splicing', () => {
-	it('should be able to splice the array returned from getAdSizeArray', () => {
-		expect(getAdSizeArray(adSizes.skyscraper).splice(0, 1)[0]).toEqual(160);
-		expect(getAdSizeArray(adSizes.skyscraper).splice(1, 1)[0]).toEqual(600);
+	it('should be able to splice the array returned from the array method on AdSize', () => {
+		expect(adSizes.skyscraper.array.splice(0, 1)[0]).toEqual(160);
+		expect(adSizes.skyscraper.array.splice(1, 1)[0]).toEqual(600);
 	});
 });

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -97,6 +97,10 @@ const createAdSize = (width: number, height: number): AdSize => {
 	return new AdSize([width, height]);
 };
 
+const getAdSizeArray = (adSize: AdSize): number[] => {
+	return [adSize.width, adSize.height];
+};
+
 const adSizesPartial = {
 	// standard ad sizes
 	billboard: createAdSize(970, 250),
@@ -314,7 +318,7 @@ const slotSizeMappings: SlotSizeMappings = {
 const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
 
 // Export for testing
-export const _ = { createAdSize };
+export const _ = { createAdSize, getAdSizeArray };
 
 export type {
 	AdSizeString,
@@ -324,4 +328,4 @@ export type {
 	SlotSizeMappings,
 	SlotName,
 };
-export { adSizes, getAdSize, slotSizeMappings, createAdSize };
+export { adSizes, getAdSize, slotSizeMappings, createAdSize, getAdSizeArray };

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -33,16 +33,16 @@ class AdSize extends Array<number> {
 			: `${this.width},${this.height}`;
 	}
 
+	public toArray(): number[] {
+		return [this[0], this[1]];
+	}
+
 	get width(): number {
 		return this[0];
 	}
 
 	get height(): number {
 		return this[1];
-	}
-
-	get array(): number[] {
-		return [this[0], this[1]];
 	}
 }
 

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -40,6 +40,10 @@ class AdSize extends Array<number> {
 	get height(): number {
 		return this[1];
 	}
+
+	get array(): number[] {
+		return [this[0], this[1]];
+	}
 }
 
 type SizeKeys =
@@ -95,10 +99,6 @@ type SlotSizeMappings = Record<SlotName, SizeMapping>;
 
 const createAdSize = (width: number, height: number): AdSize => {
 	return new AdSize([width, height]);
-};
-
-const getAdSizeArray = (adSize: AdSize): number[] => {
-	return [adSize.width, adSize.height];
 };
 
 const adSizesPartial = {
@@ -318,7 +318,7 @@ const slotSizeMappings: SlotSizeMappings = {
 const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
 
 // Export for testing
-export const _ = { createAdSize, getAdSizeArray };
+export const _ = { createAdSize };
 
 export type {
 	AdSizeString,
@@ -328,4 +328,4 @@ export type {
 	SlotSizeMappings,
 	SlotName,
 };
-export { adSizes, getAdSize, slotSizeMappings, createAdSize, getAdSizeArray };
+export { adSizes, getAdSize, slotSizeMappings, createAdSize };


### PR DESCRIPTION
## What does this change?

Adding a new function to return the array of a given ad size, and added some relevant tests to make sure the function behaves as expected.

## Why?

This will be useful in frontend to make sure that we send arrays with working array methods on them, such as splice.