### PR TITLE
refactor: Refactor `setProperty`

### DIFF
--- a/src/event-timer.ts
+++ b/src/event-timer.ts
@@ -183,16 +183,11 @@ export class EventTimer {
 	 * Adds an event timer property
 	 *
 	 * @param {string} name - the property's name
-	 * @param {value} number - the property's value
+	 * @param value - the property's value
 	 */
-	setProperty(
-		name:
-			| 'adSlotsInline'
-			| 'adSlotsTotal'
-			| 'pageHeightVH'
-			| 'gpcSignal'
-			| 'lazyLoadMarginPercent',
-		value: number,
+	setProperty<T extends keyof EventTimerProperties>(
+		name: T,
+		value: EventTimerProperties[T],
 	): void {
 		this.properties[name] = value;
 	}

--- a/src/track-labs-container.ts
+++ b/src/track-labs-container.ts
@@ -13,7 +13,7 @@ const initTrackLabsContainer = () => {
 	const eventTimer = EventTimer.get();
 
 	log('commercial', 'Page has labs container');
-	eventTimer.properties['hasLabsContainer'] = true;
+	eventTimer.setProperty('hasLabsContainer', true);
 
 	const observer = new IntersectionObserver((entries) => {
 		entries.map((entry) => {


### PR DESCRIPTION
Co-Authored-By: Zeke Hunter-Green <17057932+zekehuntergreen@users.noreply.github.com>

## What does this change?

Refactor `setProperty` so it takes into account the type of the property being set. Previously it only supported setting number values.

## Why?

Now we can use `setProperty` in `initTrackLabsContainer` to set the boolean property `hasLabsContainer` instead of writing to the `properties` object directly, which wasn't a great solution.