### PR TITLE
feat: Capture `labsUrl` when container is present

### DIFF
--- a/src/event-timer.ts
+++ b/src/event-timer.ts
@@ -45,6 +45,7 @@ interface EventTimerProperties {
 	// distance in percentage of viewport height at which ads are lazy loaded
 	lazyLoadMarginPercent?: number;
 	hasLabsContainer?: boolean;
+	labsUrl?: string;
 }
 
 export class EventTimer {

--- a/src/track-labs-container.spec.ts
+++ b/src/track-labs-container.spec.ts
@@ -27,19 +27,29 @@ describe('initTrackLabsContainer', () => {
 		initTrackLabsContainer();
 
 		expect(eventTimer.properties['hasLabsContainer']).toBeUndefined();
+		expect(eventTimer.properties['labsUrl']).toBeUndefined();
 		expect(observe).not.toHaveBeenCalled();
 	});
 
-	test('When a labs container is present on the page, observe is called', () => {
+	test('When a labs container is present on the page, the relevant properties are set and observe is called', () => {
 		const section = document.createElement('section');
 		section.className = 'dumathoin';
 		document.body.appendChild(section);
+
+		const title = document.createElement('h1');
+		title.className = 'dumathoin__title';
+		section.appendChild(title);
+
+		const link = document.createElement('a');
+		link.href = '/eat-more-potatoes';
+		title.appendChild(link);
 
 		const eventTimer = EventTimer.get();
 
 		initTrackLabsContainer();
 
 		expect(eventTimer.properties['hasLabsContainer']).toEqual(true);
+		expect(eventTimer.properties['labsUrl']).toEqual('/eat-more-potatoes');
 		expect(observe).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/track-labs-container.ts
+++ b/src/track-labs-container.ts
@@ -10,10 +10,16 @@ const initTrackLabsContainer = () => {
 	const target = document.querySelector('section.dumathoin');
 	if (target === null) return;
 
+	const labsUrl = document
+		.querySelector('h1.dumathoin__title a')
+		?.getAttribute('href');
+	if (labsUrl === null) return;
+
 	const eventTimer = EventTimer.get();
 
 	log('commercial', 'Page has labs container');
 	eventTimer.setProperty('hasLabsContainer', true);
+	eventTimer.setProperty('labsUrl', labsUrl);
 
 	const observer = new IntersectionObserver((entries) => {
 		entries.map((entry) => {


### PR DESCRIPTION
## What does this change?

Follows on from https://github.com/guardian/commercial-core/pull/665

Modifies `initTrackLabsContainer` to also capture `labsUrl` when a Guardian Labs container is present. 

In the below case, it would set `labsUrl` to `/a-vision-for-better-food`

![Screenshot 2022-09-15 at 09 03 05](https://user-images.githubusercontent.com/7423751/190349598-59e1ed04-c8a3-4506-92d0-f82945bf028b.png)

## Why?

So we know which campaign the reader saw.
