### PR TITLE
feat: upgrade Typescript and add new global types

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "semantic-release": "^19.0.2",
     "ts-jest": "^27.0.7",
     "type-fest": "^2.8.0",
-    "typescript": "^4.5.2",
+    "typescript": "^4.8.3",
     "web-vitals": "^2.1.2"
   },
   "publishConfig": {

--- a/src/global.ts
+++ b/src/global.ts
@@ -6,10 +6,28 @@ import type {
 import type { EventTimer } from '.';
 
 declare global {
+	/**
+	 * lib.dom.d.ts only includes features that are supported in at least two main browsers.
+	 * NetworkInformation is supported in Chrome only – it's behind a flag in Firefox.
+	 * If or when the NetworkInformation API is more widely supported, we can remove this shim.
+	 * https://github.com/mdn/browser-compat-data/blob/main/api/NetworkInformation.json
+	 */
+	type ConnectionType =
+		| 'bluetooth'
+		| 'cellular'
+		| 'ethernet'
+		| 'mixed'
+		| 'none'
+		| 'other'
+		| 'unknown'
+		| 'wifi';
 	interface NetworkInformation extends EventTarget {
 		readonly type: ConnectionType;
 		readonly downlink?: number;
 		readonly effectiveType?: string;
+	}
+	interface Navigator {
+		connection: NetworkInformation;
 	}
 	interface Window {
 		google_trackConversion?: (arg0: GoogleTrackConversionObject) => void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6988,10 +6988,15 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.5.2, typescript@^4.6.4:
+typescript@^4.6.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@^4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 uglify-js@^3.1.4:
   version "3.14.5"


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

- upgrade typescript to v4.8
- add types that appear to have been dropped (builds on #350)

## Why?

Keeping fresh, and alignment with csnx