### PR TITLE
fix: use old type import syntax for compatibility with frontend

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,10 +53,10 @@ export { getSharedTargeting } from './targeting/shared';
 export type { ViewportTargeting } from './targeting/viewport';
 export { getViewportTargeting } from './targeting/viewport';
 export { pickTargetingValues } from './targeting/pick-targeting-values';
-export {
-	init as initMessenger,
-	type RegisterListener,
-	type RegisterPersistentListener,
-	type RespondProxy,
+export { init as initMessenger } from './messenger';
+export type {
+	RegisterListener,
+	RegisterPersistentListener,
+	RespondProxy,
 } from './messenger';
 export { postMessage } from './messenger/post-message';


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Use old type import syntax

## Why?
Frontend on typescript 4.1 doesn't support `import { type SomeType }` syntax, it's left as is in the generated type definition.

Other than downgrading the typescript version I can't think of a way to prevent this mistake happening again, so eslint rules I can see.