### PR TITLE
feat: Migrate `build-page-targeting` from frontend

### DIFF
--- a/src/create-ad-slot.spec.ts
+++ b/src/create-ad-slot.spec.ts
@@ -19,12 +19,21 @@ const inline1Html = `
 </div>
 `;
 
+const DEFAULT_CONFIG = {
+	isDotcomRendering: true,
+	ophan: { pageViewId: 'pv_id_1234567890' },
+	page: {
+		pageId: 'world/uk',
+		isSensitive: false,
+		section: 'uk-news',
+		videoDuration: 63,
+	},
+};
+
 describe('Create Ad Slot', () => {
 	beforeEach(() => {
 		window.guardian = {
-			config: {
-				isDotcomRendering: true,
-			},
+			config: DEFAULT_CONFIG,
 		};
 	});
 	it('should exist', () => {

--- a/src/create-ad-slot.ts
+++ b/src/create-ad-slot.ts
@@ -85,7 +85,7 @@ const createAdSlotElement = (
 	const id = `${adSlotIdPrefix}${name}`;
 
 	// 3562dc07-78e9-4507-b922-78b979d4c5cb
-	if (window.guardian.config?.isDotcomRendering && name === 'top-above-nav') {
+	if (window.guardian.config.isDotcomRendering && name === 'top-above-nav') {
 		// This is to prevent a problem that appeared with DCR.
 		// We are simply making sure that if we are about to
 		// introduce dfp-ad--top-above-nav then there isn't already one.

--- a/src/event-timer.spec.ts
+++ b/src/event-timer.spec.ts
@@ -41,6 +41,17 @@ const MARK_LONG_NAME = `gu.commercial.${MARK_NAME}`;
 const CMP_INIT = 'cmp-tcfv2-init';
 const CMP_GOT_CONSENT = 'cmp-tcfv2-got-consent';
 
+const DEFAULT_CONFIG = {
+	isDotcomRendering: true,
+	ophan: { pageViewId: 'pv_id_1234567890' },
+	page: {
+		pageId: 'world/uk',
+		isSensitive: false,
+		section: 'uk-news',
+		videoDuration: 63,
+	},
+};
+
 describe('EventTimer', () => {
 	beforeEach(() => {
 		Object.defineProperty(window, 'performance', {
@@ -52,6 +63,7 @@ describe('EventTimer', () => {
 
 		window.guardian = {
 			config: {
+				...DEFAULT_CONFIG,
 				googleAnalytics: {
 					trackers: {
 						editorial: 'gaTrackerTest',

--- a/src/global.ts
+++ b/src/global.ts
@@ -20,7 +20,7 @@ declare global {
 		}>;
 		guardian: {
 			commercialTimer?: EventTimer;
-			config?: GuardianWindowConfig;
+			config: GuardianWindowConfig;
 		};
 		ga: UniversalAnalytics.ga | null;
 		readonly navigator: Navigator;

--- a/src/google-analytics.spec.ts
+++ b/src/google-analytics.spec.ts
@@ -5,11 +5,21 @@ const PERFORMANCE_NOW = 1;
 const TIMING_CATEGORY = 'TIMING_CATEGORY';
 const TIMING_VAR = 'TIMING_VAR';
 const TIMING_LABEL = 'TIMING_LABEL';
-const GUARDIAN_CONFIG = {
+const GA_CONFIG = {
 	googleAnalytics: {
 		trackers: {
 			editorial: 'gaTrackerTest',
 		},
+	},
+};
+const DEFAULT_CONFIG = {
+	isDotcomRendering: true,
+	ophan: { pageViewId: 'pv_id_1234567890' },
+	page: {
+		pageId: 'world/uk',
+		isSensitive: false,
+		section: 'uk-news',
+		videoDuration: 63,
 	},
 };
 
@@ -22,7 +32,7 @@ describe('trackEvent', () => {
 
 	it('trackEvent makes no call to ga when ga undefined', () => {
 		window.guardian = {
-			config: GUARDIAN_CONFIG,
+			config: { ...DEFAULT_CONFIG, ...GA_CONFIG },
 		};
 		Object.defineProperty(window, 'ga', {
 			configurable: true,
@@ -36,7 +46,7 @@ describe('trackEvent', () => {
 
 	it('trackEvent makes one call to ga with tracker name from config', () => {
 		window.guardian = {
-			config: GUARDIAN_CONFIG,
+			config: { ...DEFAULT_CONFIG, ...GA_CONFIG },
 		};
 		Object.defineProperty(window, 'ga', {
 			configurable: true,
@@ -59,7 +69,7 @@ describe('trackEvent', () => {
 	});
 	it('trackEvent makes one call to ga with default tracker name when config undefined', () => {
 		window.guardian = {
-			config: undefined,
+			config: DEFAULT_CONFIG,
 		};
 		Object.defineProperty(window, 'ga', {
 			configurable: true,

--- a/src/google-analytics.ts
+++ b/src/google-analytics.ts
@@ -5,7 +5,7 @@ export const trackEvent = (
 ): void => {
 	const { ga, guardian } = window;
 	const trackerName: string | undefined =
-		guardian.config?.googleAnalytics?.trackers.editorial;
+		guardian.config.googleAnalytics?.trackers.editorial;
 
 	if (typeof ga !== 'function') {
 		return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,3 +60,4 @@ export type {
 	RespondProxy,
 } from './messenger';
 export { postMessage } from './messenger/post-message';
+export { buildPageTargeting } from './targeting/build-page-targeting';

--- a/src/targeting/build-page-targeting.ts
+++ b/src/targeting/build-page-targeting.ts
@@ -73,14 +73,6 @@ const buildPageTargeting = (
 	countryCode: CountryCode,
 	clientSideParticipations: Participations,
 ): PageTargeting => {
-	if (
-		!window.guardian.config.page ||
-		!window.guardian.config.ophan ||
-		window.guardian.config.isDotcomRendering === undefined
-	) {
-		return {};
-	}
-
 	const { page, isDotcomRendering } = window.guardian.config;
 
 	const adFreeTargeting: { af?: True } = adFree ? { af: 't' } : {};

--- a/src/targeting/build-page-targeting.ts
+++ b/src/targeting/build-page-targeting.ts
@@ -1,0 +1,150 @@
+import type { Participations } from '@guardian/ab-core';
+import { cmp } from '@guardian/consent-management-platform';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import type { CountryCode } from '@guardian/libs';
+import { getCookie, isString } from '@guardian/libs';
+import type { False, True } from '../types';
+import type { ContentTargeting } from './content';
+import { getContentTargeting } from './content';
+import type { AdManagerGroup, Frequency } from './personalised';
+import { getPersonalisedTargeting } from './personalised';
+import type { SessionTargeting } from './session';
+import { getSessionTargeting } from './session';
+import type { SharedTargeting } from './shared';
+import { getSharedTargeting } from './shared';
+import type { ViewportTargeting } from './viewport';
+import { getViewportTargeting } from './viewport';
+
+type PartialWithNulls<T> = { [P in keyof T]?: T[P] | null };
+
+type TrueOrFalse = True | False;
+
+type PageTargeting = PartialWithNulls<
+	{
+		ab: string[];
+		af: 't'; // Ad Free
+		amtgrp: AdManagerGroup;
+		at: string; // Ad Test
+		bp: 'mobile' | 'tablet' | 'desktop'; // BreakPoint
+		cc: CountryCode; // Country Code
+		cmp_interaction: string;
+		consent_tcfv2: string;
+		dcre: TrueOrFalse; // DotCom-Rendering Eligible
+		fr: Frequency; // FRequency
+		inskin: TrueOrFalse; // InSkin
+		pa: TrueOrFalse; // Personalised Ads consent
+		permutive: string[]; // predefined segment values
+		pv: string; // ophan Page View id
+		rdp: string;
+		ref: string; // REFerrer
+		rp: 'dotcom-rendering' | 'dotcom-platform'; // Rendering Platform
+		s: string; // site Section
+		sens: TrueOrFalse; // SenSitive
+		si: TrueOrFalse; // Signed In
+		skinsize: 'l' | 's';
+		urlkw: string[]; // URL KeyWords
+		vl: string; // Video Length
+
+		// And more
+		[_: string]: string | string[];
+	} & SharedTargeting
+>;
+
+const filterEmptyValues = (pageTargets: Record<string, unknown>) => {
+	const filtered: Record<string, string | string[]> = {};
+	for (const key in pageTargets) {
+		const value = pageTargets[key];
+		if (isString(value)) {
+			filtered[key] = value;
+		} else if (
+			Array.isArray(value) &&
+			value.length > 0 &&
+			value.every(isString)
+		) {
+			filtered[key] = value;
+		}
+	}
+	return filtered;
+};
+
+const buildPageTargeting = (
+	consentState: ConsentState,
+	adFree: boolean,
+	countryCode: CountryCode,
+	clientSideParticipations: Participations,
+): PageTargeting => {
+	if (
+		!window.guardian.config.page ||
+		!window.guardian.config.ophan ||
+		window.guardian.config.isDotcomRendering === undefined
+	) {
+		return {};
+	}
+
+	const { page, isDotcomRendering } = window.guardian.config;
+
+	const adFreeTargeting: { af?: True } = adFree ? { af: 't' } : {};
+
+	const contentTargeting: ContentTargeting = getContentTargeting({
+		eligibleForDCR: isDotcomRendering,
+		path: `/${page.pageId}`,
+		renderingPlatform: isDotcomRendering
+			? 'dotcom-rendering'
+			: 'dotcom-platform',
+		section: page.section,
+		sensitive: page.isSensitive,
+		videoLength: page.videoDuration,
+	});
+
+	const getReferrer = () => document.referrer || '';
+
+	const sessionTargeting: SessionTargeting = getSessionTargeting({
+		adTest: getCookie({ name: 'adtest', shouldMemoize: true }),
+		countryCode,
+		isSignedIn: !!getCookie({ name: 'GU_U' }),
+		pageViewId: window.guardian.config.ophan.pageViewId,
+		participations: {
+			clientSideParticipations,
+			serverSideParticipations: window.guardian.config.tests ?? {},
+		},
+		referrer: getReferrer(),
+	});
+
+	type Viewport = { width: number; height: number };
+
+	const getViewport = (): Viewport => {
+		return {
+			width: window.innerWidth || document.body.clientWidth || 0,
+			height: window.innerHeight || document.body.clientHeight || 0,
+		};
+	};
+
+	const viewportTargeting: ViewportTargeting = getViewportTargeting({
+		viewPortWidth: getViewport().width,
+		cmpBannerWillShow:
+			!cmp.hasInitialised() || cmp.willShowPrivacyMessageSync(),
+	});
+
+	const sharedAdTargeting = page.sharedAdTargeting
+		? getSharedTargeting(page.sharedAdTargeting)
+		: {};
+
+	const personalisedTargeting = getPersonalisedTargeting(consentState);
+
+	const pageTargets: PageTargeting = {
+		...personalisedTargeting,
+		...sharedAdTargeting,
+		...adFreeTargeting,
+		...contentTargeting,
+		...sessionTargeting,
+		...viewportTargeting,
+	};
+
+	// filter out empty values
+	const pageTargeting = filterEmptyValues(pageTargets);
+
+	return pageTargeting;
+};
+
+export { buildPageTargeting };
+export type { PageTargeting };

--- a/src/targeting/personalised.ts
+++ b/src/targeting/personalised.ts
@@ -20,6 +20,8 @@ const frequency = [
 	'30plus',
 ] as const;
 
+type Frequency = typeof frequency[number];
+
 const AMTGRP_STORAGE_KEY = 'gu.adManagerGroup';
 const adManagerGroups = [
 	'1',
@@ -82,7 +84,7 @@ type PersonalisedTargeting = {
 	 *
 	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=214647
 	 */
-	fr: typeof frequency[number];
+	fr: Frequency;
 
 	/**
 	 * **P**ersonalised **A**ds Consent – [see on Ad Manager][gam]
@@ -243,4 +245,4 @@ const getPersonalisedTargeting = (
 });
 
 export { getPersonalisedTargeting };
-export type { PersonalisedTargeting };
+export type { PersonalisedTargeting, AdManagerGroup, Frequency };

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,13 +26,13 @@ export type GuardianAnalyticsConfig = {
 
 export type GuardianWindowConfig = {
 	googleAnalytics?: GuardianAnalyticsConfig;
-	isDotcomRendering?: boolean;
-	ophan?: {
+	isDotcomRendering: boolean;
+	ophan: {
 		// somewhat redundant with guardian.ophan
 		pageViewId: string;
 		browserId?: string;
 	};
-	page?: {
+	page: {
 		sharedAdTargeting?: Record<string, string | string[]>;
 		pageAdTargeting?: Record<string, string | string[]>;
 		isSensitive: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,23 @@ export type GuardianAnalyticsConfig = {
 export type GuardianWindowConfig = {
 	googleAnalytics?: GuardianAnalyticsConfig;
 	isDotcomRendering?: boolean;
+	ophan?: {
+		// somewhat redundant with guardian.ophan
+		pageViewId: string;
+		browserId?: string;
+	};
+	page?: {
+		sharedAdTargeting?: Record<string, string | string[]>;
+		pageAdTargeting?: Record<string, string | string[]>;
+		isSensitive: boolean;
+		pageId: string;
+		section: string;
+		videoDuration: number;
+	};
+	tests?: {
+		[key: `${string}Control`]: 'control';
+		[key: `${string}Variant`]: 'variant';
+	};
 };
 
 export type GoogleTagParams = unknown;


### PR DESCRIPTION
Co-authored-by: Ravi <7014230+arelra@users.noreply.github.com>
Co-authored-by: Zeke Hunter-Green <zeke.huntergreen@guardian.co.uk>

## What does this change?

Moves the logic to build page targeting from [frontend](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts). A subsequent PR in frontend will remove the old logic and instead call this method. After that, we'll do the same for DCR.

## Why?

So we can standardise the way we build page targeting across DCR and frontend. Currently there is a lot of duplication and inconsistency.