### PR TITLE
feat: Export standard ad sizes

### DIFF
--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -102,8 +102,7 @@ const createAdSize = (width: number, height: number): AdSize => {
 	return new AdSize([width, height]);
 };
 
-const adSizesPartial = {
-	// standard ad sizes
+const namedStandardAdSizes = {
 	billboard: createAdSize(970, 250),
 	halfPage: createAdSize(300, 600),
 	leaderboard: createAdSize(728, 90),
@@ -111,13 +110,24 @@ const adSizesPartial = {
 	mpu: createAdSize(300, 250),
 	portrait: createAdSize(300, 1050),
 	skyscraper: createAdSize(160, 600),
+};
 
-	// dfp proprietary ad sizes
+const standardAdSizes = {
+	'970x250': namedStandardAdSizes.billboard,
+	'300x600': namedStandardAdSizes.halfPage,
+	'728x90': namedStandardAdSizes.leaderboard,
+	'300x250': namedStandardAdSizes.mpu,
+	'300x1050': namedStandardAdSizes.portrait,
+	'160x600': namedStandardAdSizes.skyscraper,
+};
+
+const dfpProprietaryAdSizes = {
 	fluid: createAdSize(0, 0),
 	googleCard: createAdSize(300, 274),
 	outOfPage: createAdSize(1, 1),
+};
 
-	// guardian proprietary ad sizes
+const guardianProprietaryAdSizes = {
 	empty: createAdSize(2, 2),
 	fabric: createAdSize(88, 71),
 	inlineMerchandising: createAdSize(88, 85),
@@ -131,13 +141,10 @@ const adSizesPartial = {
 };
 
 const adSizes: Record<SizeKeys, AdSize> = {
-	...adSizesPartial,
-	'970x250': adSizesPartial.billboard,
-	'728x90': adSizesPartial.leaderboard,
-	'300x250': adSizesPartial.mpu,
-	'300x600': adSizesPartial.halfPage,
-	'300x1050': adSizesPartial.portrait,
-	'160x600': adSizesPartial.skyscraper,
+	...namedStandardAdSizes,
+	...standardAdSizes,
+	...dfpProprietaryAdSizes,
+	...guardianProprietaryAdSizes,
 };
 
 /**
@@ -329,4 +336,5 @@ export type {
 	SlotSizeMappings,
 	SlotName,
 };
-export { adSizes, getAdSize, slotSizeMappings, createAdSize };
+
+export { adSizes, standardAdSizes, getAdSize, slotSizeMappings, createAdSize };

--- a/src/constants/adLabelHeight.ts
+++ b/src/constants/adLabelHeight.ts
@@ -1,0 +1,4 @@
+/**
+ * Unit: pixels
+ */
+export const AD_LABEL_HEIGHT = 24;

--- a/src/constants/index.spec.ts
+++ b/src/constants/index.spec.ts
@@ -1,4 +1,4 @@
-import { PREBID_TIMEOUT, TOP_ABOVE_NAV_HEIGHT } from '.';
+import { AD_LABEL_HEIGHT, PREBID_TIMEOUT, TOP_ABOVE_NAV_HEIGHT } from '.';
 
 // These tests ensure that we look twice when changing a constant
 
@@ -9,5 +9,9 @@ describe('Constant values are constant', () => {
 
 	test('PREBID_TIMEOUT', () => {
 		expect(PREBID_TIMEOUT).toBe(1500);
+	});
+
+	test('PREBID_TIMEOUT', () => {
+		expect(AD_LABEL_HEIGHT).toBe(24);
 	});
 });

--- a/src/constants/index.spec.ts
+++ b/src/constants/index.spec.ts
@@ -11,7 +11,7 @@ describe('Constant values are constant', () => {
 		expect(PREBID_TIMEOUT).toBe(1500);
 	});
 
-	test('PREBID_TIMEOUT', () => {
+	test('AD_LABEL_HEIGHT', () => {
 		expect(AD_LABEL_HEIGHT).toBe(24);
 	});
 });

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,3 @@
+export { AD_LABEL_HEIGHT } from './adLabelHeight';
 export { PREBID_TIMEOUT } from './prebid-timeout';
 export { TOP_ABOVE_NAV_HEIGHT } from './top-above-nav-height';

--- a/src/constants/prebid-timeout.ts
+++ b/src/constants/prebid-timeout.ts
@@ -1,12 +1,4 @@
 /**
- * Unit: milliseconds.
- *
- * This value is currently being investigated.
+ * Unit: milliseconds
  */
 export const PREBID_TIMEOUT = 1500;
-
-/*
-
-cc @chrislomaxjones
-
-*/

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,13 @@ export {
 	initCommercialMetrics,
 } from './send-commercial-metrics';
 export type { ThirdPartyTag } from './types';
-export { adSizes, getAdSize, slotSizeMappings, createAdSize } from './ad-sizes';
+export {
+	adSizes,
+	standardAdSizes,
+	getAdSize,
+	slotSizeMappings,
+	createAdSize,
+} from './ad-sizes';
 export { isBreakpoint } from './lib/breakpoint';
 export type { Breakpoint } from './lib/breakpoint';
 export type {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

1. Exports standard ad sizes
2. Adds ad label height to constants

## Why?

1. So that in other apps we can distinguish between standard ad-sizes and sizes that are variable (e.g. fluid) or do not show up on the page (e.g. [1,1 ], [2, 2]) or look like a standard ad size but are actually variable (e.g. merchandising slot: [88, 87]). It will be useful in frontend to know if the top-above-ad is of a standard ad size or a fluid ad. I don't want to duplicate ad sizes in the frontend repo.
2. We define this constant in multiple places in both frontend and dotcom-rendering. Best to define it in one place that makes sense.
