### PR TITLE
feat: Build consentless page targeting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,3 +61,4 @@ export type {
 } from './messenger';
 export { postMessage } from './messenger/post-message';
 export { buildPageTargeting } from './targeting/build-page-targeting';
+export { buildPageTargetingConsentless } from './targeting/build-page-targeting-consentless';

--- a/src/targeting/build-page-targeting-consentless.ts
+++ b/src/targeting/build-page-targeting-consentless.ts
@@ -34,9 +34,8 @@ type ConsentlessPageTargeting = Partial<
 	Pick<PageTargeting, ConsentlessTargetingKeys>
 >;
 
-const isConsentlessKey = (key: unknown): key is ConsentlessTargetingKeys => {
-	return consentlessTargetingKeys.includes(key as ConsentlessTargetingKeys);
-};
+const isConsentlessKey = (key: unknown): key is ConsentlessTargetingKeys =>
+	consentlessTargetingKeys.includes(key as ConsentlessTargetingKeys);
 
 /**
  * Call buildPageTargeting then filter out the keys that are not needed for

--- a/src/targeting/build-page-targeting-consentless.ts
+++ b/src/targeting/build-page-targeting-consentless.ts
@@ -1,0 +1,68 @@
+import type { Participations } from '@guardian/ab-core';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import type { CountryCode } from '@guardian/libs';
+import type { PageTargeting } from './build-page-targeting';
+import { buildPageTargeting } from './build-page-targeting';
+
+const consentlessTargetingKeys = [
+	'ab',
+	'at',
+	'bl',
+	'bp',
+	'br',
+	'cc',
+	'ct',
+	'dcre',
+	'edition',
+	'k',
+	'rp',
+	's',
+	'se',
+	'sens',
+	'sh',
+	'si',
+	'skinsize',
+	'su',
+	'tn',
+	'url',
+	'urlkw',
+] as const;
+
+type ConsentlessTargetingKeys = typeof consentlessTargetingKeys[number];
+
+type ConsentlessPageTargeting = Partial<
+	Pick<PageTargeting, ConsentlessTargetingKeys>
+>;
+
+const isConsentlessKey = (key: unknown): key is ConsentlessTargetingKeys => {
+	return consentlessTargetingKeys.includes(key as ConsentlessTargetingKeys);
+};
+
+/**
+ * Call buildPageTargeting then filter out the keys that are not needed for
+ * consentless targeting.
+ *
+ * @param  {ConsentState} consentState
+ * @returns {ConsentlessPageTargeting}
+ */
+const buildPageTargetingConsentless = (
+	consentState: ConsentState,
+	adFree: boolean,
+	countryCode: CountryCode,
+	clientSideParticipations: Participations,
+): ConsentlessPageTargeting => {
+	const consentedPageTargeting: PageTargeting = buildPageTargeting(
+		consentState,
+		adFree,
+		countryCode,
+		clientSideParticipations,
+	);
+
+	return Object.fromEntries(
+		Object.entries(consentedPageTargeting).filter(([k]) =>
+			isConsentlessKey(k),
+		),
+	);
+};
+
+export { buildPageTargetingConsentless };

--- a/src/targeting/build-page-targeting-consentless.ts
+++ b/src/targeting/build-page-targeting-consentless.ts
@@ -43,7 +43,10 @@ const isConsentlessKey = (key: unknown): key is ConsentlessTargetingKeys => {
  * consentless targeting.
  *
  * @param  {ConsentState} consentState
- * @returns {ConsentlessPageTargeting}
+ * @param  {boolean} adFree
+ * @param  {CountryCode} countryCode
+ * @param  {Participations} clientSideParticipations
+ * @returns ConsentlessPageTargeting
  */
 const buildPageTargetingConsentless = (
 	consentState: ConsentState,


### PR DESCRIPTION
Co-Authored-By: Jake Lee Kennedy <jake@bodhi.io>

## What does this change?
- adds function `buildPageTargetingConsentless` which calls the consented version, `buildPageTargeting` and returns only the targeting key / values needed for Opt Out integration

## Why?
- Custom targeting functionality is needed to release our Opt Out integration, showing real ads to readers.