### PR TITLE
feat: Remove `countryCode` parameter from `buildPageTargeting` and add spec

### DIFF
--- a/src/create-ad-slot.spec.ts
+++ b/src/create-ad-slot.spec.ts
@@ -27,6 +27,7 @@ const DEFAULT_CONFIG = {
 		isSensitive: false,
 		section: 'uk-news',
 		videoDuration: 63,
+		edition: 'UK' as const,
 	},
 };
 

--- a/src/event-timer.spec.ts
+++ b/src/event-timer.spec.ts
@@ -49,6 +49,7 @@ const DEFAULT_CONFIG = {
 		isSensitive: false,
 		section: 'uk-news',
 		videoDuration: 63,
+		edition: 'UK' as const,
 	},
 };
 

--- a/src/google-analytics.spec.ts
+++ b/src/google-analytics.spec.ts
@@ -20,6 +20,7 @@ const DEFAULT_CONFIG = {
 		isSensitive: false,
 		section: 'uk-news',
 		videoDuration: 63,
+		edition: 'UK' as const,
 	},
 };
 

--- a/src/lib/get-locale.spec.ts
+++ b/src/lib/get-locale.spec.ts
@@ -1,0 +1,67 @@
+import { removeCookie, setCookie, storage } from '@guardian/libs';
+import { __resetCachedValue, getLocale } from './get-locale';
+
+const KEY = 'GU_geo_country';
+const KEY_OVERRIDE = 'gu.geo.override';
+
+describe('getLocale', () => {
+	beforeEach(() => {
+		storage.local.clear();
+		removeCookie({ name: KEY });
+		__resetCachedValue();
+	});
+
+	it('returns overridden locale if it is valid', () => {
+		storage.local.set(KEY_OVERRIDE, 'GE');
+		setCookie({ name: KEY, value: 'GB' });
+
+		const locale = getLocale();
+
+		expect(locale).toBe('GE');
+	});
+
+	it('ignores overridden locale if it is not valid', () => {
+		storage.local.set(KEY_OVERRIDE, 'outerspace');
+		setCookie({ name: KEY, value: 'CZ' });
+
+		const locale = getLocale();
+
+		expect(locale).toBe('CZ');
+	});
+
+	it('returns locale from a cookie', () => {
+		setCookie({ name: KEY, value: 'CY' });
+
+		const locale = getLocale();
+
+		expect(locale).toBe('CY');
+	});
+
+	it('returns the locale from edition', () => {
+		window.guardian = {
+			config: {
+				page: {
+					edition: 'AU',
+				} as unknown as typeof window.guardian.config.page,
+			} as unknown as typeof window.guardian.config,
+		};
+
+		const locale = getLocale();
+
+		expect(locale).toBe('AU');
+	});
+
+	it('uses the cached value if available', () => {
+		setCookie({ name: KEY, value: 'NE' });
+
+		// First call
+		getLocale();
+
+		storage.local.set(KEY_OVERRIDE, 'ZA');
+
+		// Second call
+		const locale2 = getLocale();
+
+		expect(locale2).toBe('NE');
+	});
+});

--- a/src/lib/get-locale.ts
+++ b/src/lib/get-locale.ts
@@ -1,0 +1,54 @@
+import type { CountryCode } from '@guardian/libs';
+import { getCookie, isString, storage } from '@guardian/libs';
+import type { Edition } from '../types';
+
+const KEY = 'GU_geo_country';
+const KEY_OVERRIDE = 'gu.geo.override';
+const COUNTRY_REGEX = /^[A-Z]{2}$/;
+
+// best guess that we have a valid code, without actually shipping the entire list
+const isValidCountryCode = (country: unknown): country is CountryCode =>
+	isString(country) && COUNTRY_REGEX.test(country);
+
+// we'll cache any successful lookups so we only have to do this once
+let locale: CountryCode | undefined;
+
+const editionToGeolocationMap: Record<Edition, CountryCode> = {
+	UK: 'GB',
+	US: 'US',
+	AU: 'AU',
+};
+
+const editionToGeolocation = (editionKey: Edition): CountryCode =>
+	editionToGeolocationMap[editionKey];
+
+// just used for tests
+export const __resetCachedValue = (): void => (locale = undefined);
+
+/**
+ * Fetches the user's current location as an ISO 3166-1 alpha-2 string e.g. 'GB', 'AU' etc
+ * Note: This has been copied from guardian-libs and made syncronous by ommiting the call to
+ * the geolocation API
+ */
+export const getLocale = (): CountryCode => {
+	if (locale) return locale;
+
+	// return overridden geo from localStorage, used for changing geo only for development purposes
+	const geoOverride = storage.local.get(KEY_OVERRIDE);
+	if (isValidCountryCode(geoOverride)) {
+		return (locale = geoOverride);
+	}
+
+	// return locale from cookie if it exists
+	const stored = getCookie({ name: KEY });
+	if (stored && isValidCountryCode(stored)) {
+		return (locale = stored);
+	}
+
+	// return locale from edition
+	const editionCountryCode = editionToGeolocation(
+		window.guardian.config.page.edition,
+	);
+
+	return (locale = editionCountryCode);
+};

--- a/src/targeting/build-page-targeting-consentless.ts
+++ b/src/targeting/build-page-targeting-consentless.ts
@@ -1,6 +1,5 @@
 import type { Participations } from '@guardian/ab-core';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
-import type { CountryCode } from '@guardian/libs';
 import type { PageTargeting } from './build-page-targeting';
 import { buildPageTargeting } from './build-page-targeting';
 
@@ -43,20 +42,17 @@ const isConsentlessKey = (key: unknown): key is ConsentlessTargetingKeys =>
  *
  * @param  {ConsentState} consentState
  * @param  {boolean} adFree
- * @param  {CountryCode} countryCode
  * @param  {Participations} clientSideParticipations
  * @returns ConsentlessPageTargeting
  */
 const buildPageTargetingConsentless = (
 	consentState: ConsentState,
 	adFree: boolean,
-	countryCode: CountryCode,
 	clientSideParticipations: Participations,
 ): ConsentlessPageTargeting => {
 	const consentedPageTargeting: PageTargeting = buildPageTargeting(
 		consentState,
 		adFree,
-		countryCode,
 		clientSideParticipations,
 	);
 

--- a/src/targeting/build-page-targeting.spec.ts
+++ b/src/targeting/build-page-targeting.spec.ts
@@ -1,0 +1,609 @@
+import { cmp as cmp_ } from '@guardian/consent-management-platform';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import type { TCFv2ConsentState } from '@guardian/consent-management-platform/dist/types/tcfv2';
+import { setCookie, storage } from '@guardian/libs';
+import { getLocale as getLocale_ } from '../lib/get-locale';
+import type { Edition } from '../types';
+import { buildPageTargeting } from './build-page-targeting';
+
+const getLocale = getLocale_ as jest.MockedFunction<typeof getLocale_>;
+
+const cmp = {
+	hasInitialised: cmp_.hasInitialised as jest.MockedFunction<
+		typeof cmp_.hasInitialised
+	>,
+	willShowPrivacyMessageSync:
+		cmp_.willShowPrivacyMessageSync as jest.MockedFunction<
+			typeof cmp_.willShowPrivacyMessageSync
+		>,
+};
+
+jest.mock('../lib/get-locale', () => ({
+	getLocale: jest.fn(),
+}));
+
+jest.mock('@guardian/consent-management-platform', () => ({
+	cmp: {
+		hasInitialised: jest.fn(),
+		willShowPrivacyMessageSync: jest.fn(),
+	},
+}));
+
+const mockViewport = (width: number, height: number): void => {
+	Object.defineProperties(window, {
+		innerWidth: {
+			value: width,
+		},
+		innerHeight: {
+			value: height,
+		},
+	});
+};
+
+// CCPA
+const ccpaWithConsentMock: ConsentState = {
+	ccpa: { doNotSell: false },
+	canTarget: true,
+	framework: 'ccpa',
+};
+
+const ccpaWithoutConsentMock: ConsentState = {
+	ccpa: { doNotSell: true },
+	canTarget: false,
+	framework: 'ccpa',
+};
+
+// AUS
+const ausWithConsentMock: ConsentState = {
+	aus: { personalisedAdvertising: true },
+	canTarget: true,
+	framework: 'aus',
+};
+
+const ausWithoutConsentMock: ConsentState = {
+	aus: { personalisedAdvertising: false },
+	canTarget: false,
+	framework: 'aus',
+};
+
+// TCFv2
+const defaultState: TCFv2ConsentState = {
+	consents: { 1: false },
+	eventStatus: 'tcloaded',
+	vendorConsents: { abc: false },
+	addtlConsent: 'xyz',
+	gdprApplies: true,
+	tcString: 'YAAA',
+};
+
+const tcfv2WithConsentMock: ConsentState = {
+	tcfv2: {
+		...defaultState,
+		consents: { '1': true, '2': true },
+		eventStatus: 'useractioncomplete',
+	},
+	canTarget: true,
+	framework: 'tcfv2',
+};
+
+const tcfv2WithoutConsentMock: ConsentState = {
+	tcfv2: { ...defaultState, consents: {}, eventStatus: 'cmpuishown' },
+	canTarget: false,
+	framework: 'tcfv2',
+};
+
+const tcfv2NullConsentMock: ConsentState = {
+	tcfv2: undefined,
+	canTarget: false,
+	framework: 'tcfv2',
+};
+
+const tcfv2MixedConsentMock: ConsentState = {
+	tcfv2: {
+		...defaultState,
+		consents: { '1': false, '2': true },
+		eventStatus: 'useractioncomplete',
+	},
+	canTarget: false,
+	framework: 'tcfv2',
+};
+
+const emptyConsent: ConsentState = {
+	canTarget: false,
+	framework: null,
+};
+
+describe('Build Page Targeting', () => {
+	beforeEach(() => {
+		window.guardian = {
+			config: {
+				ophan: { pageViewId: 'presetOphanPageViewId' },
+				page: {
+					edition: 'US' as Edition,
+					pageId: 'football/series/footballweekly',
+					videoDuration: 63,
+					section: 'football',
+					sharedAdTargeting: {
+						bl: ['blog'],
+						br: 'p',
+						co: ['gabrielle-chan'],
+						ct: 'video',
+						edition: 'us',
+						k: [
+							'prince-charles-letters',
+							'uk/uk',
+							'prince-charles',
+						],
+						ob: 't',
+						p: 'ng',
+						se: ['filmweekly'],
+						su: ['5'],
+						tn: ['news'],
+						url: '/football/series/footballweekly',
+					},
+					isSensitive: false,
+				} as unknown as typeof window.guardian.config.page,
+			} as unknown as typeof window.guardian.config,
+		};
+
+		setCookie({ name: 'adtest', value: 'ng101' });
+
+		mockViewport(0, 0);
+
+		setCookie({ name: 'GU_U', value: 'test' });
+
+		storage.local.setRaw('gu.alreadyVisited', String(0));
+
+		getLocale.mockReturnValue('US');
+
+		jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
+
+		expect.hasAssertions();
+	});
+
+	afterEach(() => {
+		jest.spyOn(global.Math, 'random').mockRestore();
+		jest.resetAllMocks();
+	});
+
+	it('should exist', () => {
+		expect(buildPageTargeting).toBeDefined();
+	});
+
+	it('should build correct page targeting', () => {
+		const pageTargeting = buildPageTargeting(emptyConsent, false, {});
+
+		expect(pageTargeting.sens).toBe('f');
+		expect(pageTargeting.edition).toBe('us');
+		expect(pageTargeting.ct).toBe('video');
+		expect(pageTargeting.p).toBe('ng');
+		expect(pageTargeting.su).toEqual(['5']);
+		expect(pageTargeting.bp).toBe('mobile');
+		expect(pageTargeting.at).toBe('ng101');
+		expect(pageTargeting.si).toEqual('t');
+		expect(pageTargeting.co).toEqual(['gabrielle-chan']);
+		expect(pageTargeting.bl).toEqual(['blog']);
+		expect(pageTargeting.tn).toEqual(['news']);
+		expect(pageTargeting.vl).toEqual('90');
+		expect(pageTargeting.pv).toEqual('presetOphanPageViewId');
+		expect(pageTargeting.pa).toEqual('f');
+		expect(pageTargeting.cc).toEqual('US');
+		expect(pageTargeting.rp).toEqual('dotcom-platform');
+	});
+
+	it('should set correct personalized ad (pa) param', () => {
+		expect(buildPageTargeting(tcfv2WithConsentMock, false, {}).pa).toBe(
+			't',
+		);
+		expect(buildPageTargeting(tcfv2WithoutConsentMock, false, {}).pa).toBe(
+			'f',
+		);
+		expect(buildPageTargeting(tcfv2NullConsentMock, false, {}).pa).toBe(
+			'f',
+		);
+		expect(buildPageTargeting(tcfv2MixedConsentMock, false, {}).pa).toBe(
+			'f',
+		);
+		expect(buildPageTargeting(ccpaWithConsentMock, false, {}).pa).toBe('t');
+		expect(buildPageTargeting(ccpaWithoutConsentMock, false, {}).pa).toBe(
+			'f',
+		);
+	});
+
+	it('Should correctly set the RDP flag (rdp) param', () => {
+		expect(buildPageTargeting(tcfv2WithoutConsentMock, false, {}).rdp).toBe(
+			'na',
+		);
+		expect(buildPageTargeting(tcfv2NullConsentMock, false, {}).rdp).toBe(
+			'na',
+		);
+		expect(buildPageTargeting(ccpaWithConsentMock, false, {}).rdp).toBe(
+			'f',
+		);
+		expect(buildPageTargeting(ccpaWithoutConsentMock, false, {}).rdp).toBe(
+			't',
+		);
+	});
+
+	it('Should correctly set the TCFv2 (consent_tcfv2, cmp_interaction) params', () => {
+		expect(
+			buildPageTargeting(tcfv2WithConsentMock, false, {}).consent_tcfv2,
+		).toBe('t');
+		expect(
+			buildPageTargeting(tcfv2WithConsentMock, false, {}).cmp_interaction,
+		).toBe('useractioncomplete');
+
+		expect(
+			buildPageTargeting(tcfv2WithoutConsentMock, false, {})
+				.consent_tcfv2,
+		).toBe('f');
+		expect(
+			buildPageTargeting(tcfv2WithoutConsentMock, false, {})
+				.cmp_interaction,
+		).toBe('cmpuishown');
+
+		expect(
+			buildPageTargeting(tcfv2MixedConsentMock, false, {}).consent_tcfv2,
+		).toBe('f');
+		expect(
+			buildPageTargeting(tcfv2MixedConsentMock, false, {})
+				.cmp_interaction,
+		).toBe('useractioncomplete');
+	});
+
+	it('should set correct edition param', () => {
+		expect(buildPageTargeting(emptyConsent, false, {}).edition).toBe('us');
+	});
+
+	it('should set correct se param', () => {
+		expect(buildPageTargeting(emptyConsent, false, {}).se).toEqual([
+			'filmweekly',
+		]);
+	});
+
+	it('should set correct k param', () => {
+		expect(buildPageTargeting(emptyConsent, false, {}).k).toEqual([
+			'prince-charles-letters',
+			'uk/uk',
+			'prince-charles',
+		]);
+	});
+
+	it('should set correct ab param', () => {
+		expect(
+			buildPageTargeting(emptyConsent, false, {
+				MtMaster: {
+					variant: 'variantName',
+				},
+			}).ab,
+		).toEqual(['MtMaster-variantName']);
+	});
+
+	it('should set Observer flag for Observer content', () => {
+		expect(buildPageTargeting(emptyConsent, false, {}).ob).toEqual('t');
+	});
+
+	it('should set correct branding param for paid content', () => {
+		expect(buildPageTargeting(emptyConsent, false, {}).br).toEqual('p');
+	});
+
+	it('should not contain an ad-free targeting value', () => {
+		expect(buildPageTargeting(emptyConsent, false, {}).af).toBeUndefined();
+	});
+
+	it('should remove empty values', () => {
+		window.guardian.config.page = {
+			// pageId should always be defined
+			pageId: 'football/series/footballweekly',
+		} as unknown as typeof window.guardian.config.page;
+		window.guardian.config.ophan = { pageViewId: '123456' };
+
+		expect(buildPageTargeting(emptyConsent, false, {})).toEqual({
+			at: 'ng101',
+			bp: 'mobile',
+			cc: 'US',
+			cmp_interaction: 'na',
+			consent_tcfv2: 'na',
+			dcre: 'f',
+			fr: '0',
+			inskin: 'f',
+			pa: 'f',
+			pv: '123456',
+			rdp: 'na',
+			rp: 'dotcom-platform',
+			sens: 'f',
+			si: 't',
+			skinsize: 's',
+			urlkw: ['footballweekly'],
+		});
+	});
+
+	describe('Breakpoint targeting', () => {
+		it('should set correct breakpoint targeting for a mobile device', () => {
+			mockViewport(320, 0);
+			expect(buildPageTargeting(emptyConsent, false, {}).bp).toEqual(
+				'mobile',
+			);
+		});
+
+		it('should set correct breakpoint targeting for a medium mobile device', () => {
+			mockViewport(375, 0);
+			expect(buildPageTargeting(emptyConsent, false, {}).bp).toEqual(
+				'mobile',
+			);
+		});
+
+		it('should set correct breakpoint targeting for a mobile device in landscape mode', () => {
+			mockViewport(480, 0);
+			expect(buildPageTargeting(emptyConsent, false, {}).bp).toEqual(
+				'mobile',
+			);
+		});
+
+		it('should set correct breakpoint targeting for a phablet device', () => {
+			mockViewport(660, 0);
+			expect(buildPageTargeting(emptyConsent, false, {}).bp).toEqual(
+				'tablet',
+			);
+		});
+
+		it('should set correct breakpoint targeting for a tablet device', () => {
+			mockViewport(740, 0);
+			expect(buildPageTargeting(emptyConsent, false, {}).bp).toEqual(
+				'tablet',
+			);
+		});
+
+		it('should set correct breakpoint targeting for a desktop device', () => {
+			mockViewport(980, 0);
+			expect(buildPageTargeting(emptyConsent, false, {}).bp).toEqual(
+				'desktop',
+			);
+		});
+
+		it('should set correct breakpoint targeting for a leftCol device', () => {
+			mockViewport(1140, 0);
+			expect(buildPageTargeting(emptyConsent, false, {}).bp).toEqual(
+				'desktop',
+			);
+		});
+
+		it('should set correct breakpoint targeting for a wide device', () => {
+			mockViewport(1300, 0);
+			expect(buildPageTargeting(emptyConsent, false, {}).bp).toEqual(
+				'desktop',
+			);
+		});
+	});
+
+	describe('Build Page Targeting (ad-free)', () => {
+		it('should set the ad-free param to t when enabled', () => {
+			expect(buildPageTargeting(emptyConsent, true, {}).af).toBe('t');
+		});
+	});
+
+	describe('Already visited frequency', () => {
+		it('can pass a value of five or less', () => {
+			storage.local.setRaw('gu.alreadyVisited', String(5));
+			expect(
+				buildPageTargeting(ccpaWithConsentMock, false, {}).fr,
+			).toEqual('5');
+		});
+
+		it('between five and thirty, includes it in a bucket in the form "x-y"', () => {
+			storage.local.setRaw('gu.alreadyVisited', String(18));
+			expect(
+				buildPageTargeting(ccpaWithConsentMock, false, {}).fr,
+			).toEqual('16-19');
+		});
+
+		it('over thirty, includes it in the bucket "30plus"', () => {
+			storage.local.setRaw('gu.alreadyVisited', String(300));
+			expect(
+				buildPageTargeting(ccpaWithConsentMock, false, {}).fr,
+			).toEqual('30plus');
+		});
+
+		it('passes a value of 0 if the value is not stored', () => {
+			storage.local.remove('gu.alreadyVisited');
+			expect(
+				buildPageTargeting(ccpaWithConsentMock, false, {}).fr,
+			).toEqual('0');
+		});
+
+		it('passes a value of 0 if the number is invalid', () => {
+			storage.local.setRaw('gu.alreadyVisited', 'not-a-number');
+			expect(
+				buildPageTargeting(ccpaWithConsentMock, false, {}).fr,
+			).toEqual('0');
+		});
+
+		it('passes a value of 0 if consent is not given', () => {
+			storage.local.setRaw('gu.alreadyVisited', String(5));
+			expect(
+				buildPageTargeting(ccpaWithoutConsentMock, false, {}).fr,
+			).toEqual('0');
+		});
+
+		it('passes a value of 0 if empty consent', () => {
+			storage.local.setRaw('gu.alreadyVisited', String(5));
+			expect(buildPageTargeting(emptyConsent, false, {}).fr).toEqual('0');
+		});
+	});
+
+	describe('Referrer', () => {
+		it('should set ref to Facebook', () => {
+			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
+				'https://www.facebook.com/feel-the-force',
+			);
+			expect(buildPageTargeting(emptyConsent, false, {}).ref).toEqual(
+				'facebook',
+			);
+		});
+
+		it('should set ref to Twitter', () => {
+			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
+				'https://t.co/you-must-unlearn-what-you-have-learned',
+			);
+			expect(buildPageTargeting(emptyConsent, false, {}).ref).toEqual(
+				'twitter',
+			);
+		});
+
+		it('should set ref to reddit', () => {
+			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
+				'https://www.reddit.com/its-not-my-fault',
+			);
+			expect(buildPageTargeting(emptyConsent, false, {}).ref).toEqual(
+				'reddit',
+			);
+		});
+
+		it('should set ref to google', () => {
+			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
+				'https://www.google.com/i-find-your-lack-of-faith-distrubing',
+			);
+			expect(buildPageTargeting(emptyConsent, false, {}).ref).toEqual(
+				'google',
+			);
+		});
+
+		it('should set ref empty string if referrer does not match', () => {
+			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
+				'https://theguardian.com',
+			);
+			expect(buildPageTargeting(emptyConsent, false, {}).ref).toEqual(
+				undefined,
+			);
+		});
+	});
+
+	describe('URL Keywords', () => {
+		it('should return correct keywords from pageId', () => {
+			expect(buildPageTargeting(emptyConsent, false, {}).urlkw).toEqual([
+				'footballweekly',
+			]);
+		});
+
+		it('should extract multiple url keywords correctly', () => {
+			window.guardian.config.page.pageId =
+				'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london';
+			expect(buildPageTargeting(emptyConsent, false, {}).urlkw).toEqual([
+				'harry',
+				'potter',
+				'cursed',
+				'child',
+				'review',
+				'palace',
+				'theatre',
+				'london',
+			]);
+		});
+
+		it('should get correct keywords when trailing slash is present', () => {
+			window.guardian.config.page.pageId =
+				'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
+			expect(buildPageTargeting(emptyConsent, false, {}).urlkw).toEqual([
+				'harry',
+				'potter',
+				'cursed',
+				'child',
+				'review',
+				'palace',
+				'theatre',
+				'london',
+			]);
+		});
+	});
+
+	describe('inskin targeting', () => {
+		it('should not allow inskin if cmp has not initialised', () => {
+			cmp.hasInitialised.mockReturnValue(false);
+			cmp.willShowPrivacyMessageSync.mockReturnValue(false);
+			mockViewport(1920, 1080);
+			expect(buildPageTargeting(emptyConsent, false, {}).inskin).toBe(
+				'f',
+			);
+		});
+
+		it('should not allow inskin if cmp will show a banner', () => {
+			cmp.hasInitialised.mockReturnValue(true);
+			cmp.willShowPrivacyMessageSync.mockReturnValue(true);
+			mockViewport(1920, 1080);
+			expect(buildPageTargeting(emptyConsent, false, {}).inskin).toBe(
+				'f',
+			);
+		});
+	});
+
+	describe('skinsize targetting', () => {
+		it.each([
+			['s', 1280],
+			['s', 1440],
+			['s', 1559],
+			['l', 1560],
+			['l', 1561],
+			['l', 1920],
+			['l', 2560],
+		])("should return '%s' if viewport width is %s", (expected, width) => {
+			cmp.hasInitialised.mockReturnValue(true);
+			cmp.willShowPrivacyMessageSync.mockReturnValue(false);
+			mockViewport(width, 800);
+			expect(buildPageTargeting(emptyConsent, false, {}).skinsize).toBe(
+				expected,
+			);
+		});
+
+		it("should return 's' if vp does not have a width", () => {
+			mockViewport(0, 0);
+			expect(buildPageTargeting(emptyConsent, false, {}).skinsize).toBe(
+				's',
+			);
+		});
+	});
+
+	describe('ad manager group value', () => {
+		const STORAGE_KEY = 'gu.adManagerGroup';
+		it('if present in localstorage, use value from storage', () => {
+			storage.local.setRaw(STORAGE_KEY, '10');
+			expect(
+				buildPageTargeting(tcfv2WithConsentMock, false, {}).amtgrp,
+			).toEqual('10');
+			storage.local.remove(STORAGE_KEY);
+		});
+
+		it.each([
+			[ccpaWithConsentMock, '9'],
+			[ccpaWithoutConsentMock, '9'],
+
+			[ausWithConsentMock, '9'],
+			[ausWithoutConsentMock, '9'],
+
+			[tcfv2WithConsentMock, '9'],
+			[tcfv2WithoutConsentMock, undefined],
+			[tcfv2MixedConsentMock, undefined],
+			[tcfv2MixedConsentMock, undefined],
+		])('Framework %p => amtgrp is %s', (consentState, value) => {
+			storage.local.setRaw(STORAGE_KEY, '9');
+			expect(buildPageTargeting(consentState, false, {}).amtgrp).toEqual(
+				value,
+			);
+			storage.local.remove(STORAGE_KEY);
+		});
+
+		it('if not present in localstorage, generate a random group 1-12, store in localstorage', () => {
+			// restore Math.random for this test so we can assert the group value range is 1-12
+			jest.spyOn(global.Math, 'random').mockRestore();
+			const valueGenerated = buildPageTargeting(
+				tcfv2WithConsentMock,
+				false,
+				{},
+			).amtgrp;
+			expect(valueGenerated).toBeDefined();
+			expect(Number(valueGenerated)).toBeGreaterThanOrEqual(1);
+			expect(Number(valueGenerated)).toBeLessThanOrEqual(12);
+			const valueFromStorage = storage.local.getRaw(STORAGE_KEY);
+			expect(valueFromStorage).toEqual(valueGenerated);
+		});
+	});
+});

--- a/src/targeting/build-page-targeting.ts
+++ b/src/targeting/build-page-targeting.ts
@@ -3,6 +3,7 @@ import { cmp } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { CountryCode } from '@guardian/libs';
 import { getCookie, isString } from '@guardian/libs';
+import { getLocale } from '../lib/get-locale';
 import type { False, True } from '../types';
 import type { ContentTargeting } from './content';
 import { getContentTargeting } from './content';
@@ -70,7 +71,6 @@ const filterEmptyValues = (pageTargets: Record<string, unknown>) => {
 const buildPageTargeting = (
 	consentState: ConsentState,
 	adFree: boolean,
-	countryCode: CountryCode,
 	clientSideParticipations: Participations,
 ): PageTargeting => {
 	const { page, isDotcomRendering } = window.guardian.config;
@@ -92,7 +92,7 @@ const buildPageTargeting = (
 
 	const sessionTargeting: SessionTargeting = getSessionTargeting({
 		adTest: getCookie({ name: 'adtest', shouldMemoize: true }),
-		countryCode,
+		countryCode: getLocale(),
 		isSignedIn: !!getCookie({ name: 'GU_U' }),
 		pageViewId: window.guardian.config.ophan.pageViewId,
 		participations: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export type GuardianAnalyticsConfig = {
 	trackers: Record<string, string>;
 };
 
+export type Edition = 'UK' | 'AU' | 'US';
+
 export type GuardianWindowConfig = {
 	googleAnalytics?: GuardianAnalyticsConfig;
 	isDotcomRendering: boolean;
@@ -34,11 +36,11 @@ export type GuardianWindowConfig = {
 	};
 	page: {
 		sharedAdTargeting?: Record<string, string | string[]>;
-		pageAdTargeting?: Record<string, string | string[]>;
 		isSensitive: boolean;
 		pageId: string;
 		section: string;
 		videoDuration: number;
+		edition: Edition;
 	};
 	tests?: {
 		[key: `${string}Control`]: 'control';


### PR DESCRIPTION
Co-authored-by: <ravi.lal.freelancer@guardian.co.uk>

## What does this change?

- removes the parameter `countryCode` from `buildPageTargeting()`. The country code is instead calculated directly using a script [copied from `libs`](https://github.com/guardian/csnx/blob/main/libs/%40guardian/libs/src/locale/getLocale.ts) and modified to be synchronous
- adds a spec for `buildPageTargeting`. This was based on an [existing spec in frontend](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts) which can now be removed

## Why?

Fewer arguments mean the method is simpler to consume.

The spec always belonged here and not in frontend, [as acknowledged at the time](https://github.com/guardian/frontend/pull/25556#discussion_r988886343).