### PR TITLE
feat: Vendor scripts from Frontend

### DIFF
--- a/src/__vendor/a9-apstag.js
+++ b/src/__vendor/a9-apstag.js
@@ -1,0 +1,36 @@
+/*eslint-disable */
+// Load Amazon A9 library as described here: https://ams.amazon.com/webpublisher/uam/docs/web-integration-documentation/integration-guide/javascript-guide/display.html
+export const a9Apstag = () => {
+	!(function(a9, a, p, s, t, A, g) {
+		if (a[a9]) return;
+		function q(c, r) {
+			a[a9]._Q.push([c, r]);
+		}
+		a[a9] = {
+			init() {
+				q('i', arguments);
+			},
+			fetchBids() {
+				q('f', arguments);
+			},
+			setDisplayBids() {},
+			targetingKeys() {
+				return [];
+			},
+			_Q: [],
+		};
+		A = p.createElement(s);
+		A.async = !0;
+		A.src = t;
+		g = p.getElementsByTagName(s)[0];
+
+		g.parentNode.insertBefore(A, g);
+	})(
+		'apstag',
+		window,
+		document,
+		'script',
+		'//c.amazon-adsystem.com/aax2/apstag.js'
+	);
+}
+/* eslint-enable */

--- a/src/__vendor/a9-apstag.js
+++ b/src/__vendor/a9-apstag.js
@@ -1,4 +1,3 @@
-/*eslint-disable */
 /**
  * Load Amazon A9 library as {@link https://ams.amazon.com/webpublisher/uam/docs/web-integration-documentation/integration-guide/javascript-guide/display.html described here}
  */

--- a/src/__vendor/a9-apstag.js
+++ b/src/__vendor/a9-apstag.js
@@ -2,7 +2,7 @@
  * Load Amazon A9 library as {@link https://ams.amazon.com/webpublisher/uam/docs/web-integration-documentation/integration-guide/javascript-guide/display.html described here}
  */
 export const a9Apstag = () => {
-	!(function(a9, a, p, s, t, A, g) {
+	(function(a9, a, p, s, t, A, g) {
 		if (a[a9]) return;
 		function q(c, r) {
 			a[a9]._Q.push([c, r]);

--- a/src/__vendor/a9-apstag.js
+++ b/src/__vendor/a9-apstag.js
@@ -1,5 +1,7 @@
 /*eslint-disable */
-// Load Amazon A9 library as described here: https://ams.amazon.com/webpublisher/uam/docs/web-integration-documentation/integration-guide/javascript-guide/display.html
+/**
+ * Load Amazon A9 library as {@link https://ams.amazon.com/webpublisher/uam/docs/web-integration-documentation/integration-guide/javascript-guide/display.html described here}
+ */
 export const a9Apstag = () => {
 	!(function(a9, a, p, s, t, A, g) {
 		if (a[a9]) return;
@@ -33,4 +35,3 @@ export const a9Apstag = () => {
 		'//c.amazon-adsystem.com/aax2/apstag.js'
 	);
 }
-/* eslint-enable */

--- a/src/__vendor/ipsos-mori.js
+++ b/src/__vendor/ipsos-mori.js
@@ -1,0 +1,12 @@
+// This is third party code and should not be converted to TypeScript
+// See documentation here: https://github.com/guardian/dotcom-rendering/blob/150fc2d81e6a66d9c3336185e874fc8cd0288546/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md
+
+export const ipsosMoriStub = () => {
+	window.dm = window.dm || { AjaxData: [] };
+	window.dm.AjaxEvent = (et, d, ssid, ad) => {
+		dm.AjaxData.push({ et, d, ssid, ad });
+		if (window.DotMetricsObj) {
+			DotMetricsObj.onAjaxDataUpdate();
+		}
+	};
+};

--- a/src/__vendor/ipsos-mori.js
+++ b/src/__vendor/ipsos-mori.js
@@ -1,4 +1,3 @@
-/*eslint-disable */
 /**
  * Load the Ipsos Mori Stub
  *

--- a/src/__vendor/ipsos-mori.js
+++ b/src/__vendor/ipsos-mori.js
@@ -1,6 +1,9 @@
-// This is third party code and should not be converted to TypeScript
-// See documentation here: https://github.com/guardian/dotcom-rendering/blob/150fc2d81e6a66d9c3336185e874fc8cd0288546/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md
-
+/*eslint-disable */
+/**
+ * Load the Ipsos Mori Stub
+ *
+ * See {@Link https://github.com/guardian/dotcom-rendering/blob/150fc2d81e6a66d9c3336185e874fc8cd0288546/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md documentation here }
+ */
 export const ipsosMoriStub = () => {
 	window.dm = window.dm || { AjaxData: [] };
 	window.dm.AjaxEvent = (et, d, ssid, ad) => {

--- a/src/__vendor/launchpad.js
+++ b/src/__vendor/launchpad.js
@@ -3,7 +3,7 @@
  *  and creates the global "launchpad" method
  */
 export const launchpad = () => {
-	;(function (p, l, o, w, i, n, g) {
+	(function (p, l, o, w, i, n, g) {
 		if (!p[i]) {
 			p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || [];
 			p.GlobalSnowplowNamespace.push(i);

--- a/src/__vendor/launchpad.js
+++ b/src/__vendor/launchpad.js
@@ -1,9 +1,8 @@
 /*eslint-disable */
-/*
-*  Loads the Launchpad js tracker (used by Redplanet) into the page,
-*  and creates the global "launchpad" method
-*  TODO put this file in __vendors
-*/
+/**
+ *  Loads the Launchpad js tracker (used by Redplanet) into the page,
+ *  and creates the global "launchpad" method
+ */
 export const launchpad = () => {
 	;(function (p, l, o, w, i, n, g) {
 		if (!p[i]) {

--- a/src/__vendor/launchpad.js
+++ b/src/__vendor/launchpad.js
@@ -1,4 +1,3 @@
-/*eslint-disable */
 /**
  *  Loads the Launchpad js tracker (used by Redplanet) into the page,
  *  and creates the global "launchpad" method

--- a/src/__vendor/launchpad.js
+++ b/src/__vendor/launchpad.js
@@ -1,0 +1,25 @@
+/*eslint-disable */
+/*
+*  Loads the Launchpad js tracker (used by Redplanet) into the page,
+*  and creates the global "launchpad" method
+*  TODO put this file in __vendors
+*/
+export const launchpad = () => {
+	;(function (p, l, o, w, i, n, g) {
+		if (!p[i]) {
+			p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || [];
+			p.GlobalSnowplowNamespace.push(i);
+			p[i] = function () {
+				(p[i].q = p[i].q || []).push(arguments)
+			};
+			p[i].q = p[i].q || [];
+			n = l.createElement(o);
+			g = l.getElementsByTagName(o)[0];
+
+			n.async = 1;
+			n.src = w;
+
+			g.parentNode.insertBefore(n, g)
+		}
+	}(window, document, "script", "https://lps.qantas.com/sp.js", "launchpad"));
+}

--- a/src/__vendor/pubmatic.js
+++ b/src/__vendor/pubmatic.js
@@ -1,4 +1,3 @@
-/*eslint-disable */
 /**
  * Pubmatic custom override script
  *

--- a/src/__vendor/pubmatic.js
+++ b/src/__vendor/pubmatic.js
@@ -1,6 +1,9 @@
-// Pubmatic custom override script
-// from gist.github.com/abhinavsinha001/de46bd4ac4f02d98eb50c1f4f995545e
-
+/*eslint-disable */
+/**
+ * Pubmatic custom override script
+ *
+ * From {@Link https://gist.github.com/abhinavsinha001/de46bd4ac4f02d98eb50c1f4f995545e}
+ */
 export const pubmatic = function (bid, data, acEnabled, utils, defaultFn) {
 	if (defaultFn) {
 		// keep this to move to default function once supported by RTD submodule

--- a/src/__vendor/pubmatic.js
+++ b/src/__vendor/pubmatic.js
@@ -1,0 +1,46 @@
+// Pubmatic custom override script
+// from gist.github.com/abhinavsinha001/de46bd4ac4f02d98eb50c1f4f995545e
+
+export const pubmatic = function (bid, data, acEnabled, utils, defaultFn) {
+	if (defaultFn) {
+		// keep this to move to default function once supported by RTD submodule
+		bid = defaultFn(bid, data, acEnabled);
+	} else {
+		let segments = [];
+
+		// add all user segments
+		try {
+			const psegs = JSON.parse(localStorage._psegs || '[]').map(String);
+			const ppam = JSON.parse(localStorage._ppam || '[]');
+			const pcrprs = JSON.parse(localStorage._pcrprs || '[]');
+
+			segments = [...psegs, ...ppam, ...pcrprs];
+		} catch (e) {}
+
+		// add AC specific segments (these would typically go to a separate key-value, but not sure if we can have 2 lists of segments here?)
+		if (acEnabled && data.ac && data.ac.length > 0) {
+			segments = segments.concat(data.ac);
+		}
+
+		segments = segments.map(function (seg) {
+			return { id: seg };
+		});
+
+		pbjs.setBidderConfig({
+			// Note this will replace existing bidder FPD config till merge is supported.
+			bidders: ['pubmatic'],
+			config: {
+				ortb2: {
+					user: {
+						data: [
+							{
+								name: 'permutive.com',
+								segment: segments,
+							},
+						],
+					},
+				},
+			},
+		});
+	}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,3 +70,8 @@ export { postMessage } from './messenger/post-message';
 export { buildPageTargeting } from './targeting/build-page-targeting';
 export { buildPageTargetingConsentless } from './targeting/build-page-targeting-consentless';
 export type { PageTargeting } from './targeting/build-page-targeting';
+/* -- Vendor JavaScript -- */
+export { a9Apstag } from './__vendor/a9-apstag';
+export { ipsosMoriStub } from './__vendor/ipsos-mori';
+export { launchpad } from './__vendor/launchpad';
+export { pubmatic } from './__vendor/pubmatic';


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Add the following third party scripts from Frontend to the `__vendor` directory:
- Ipsos Mori stub
- A9 Apstag
- Launchpad (used by Redplanet)
- Pubmatic override (for using Permutive audiences with Pubmatic Prebid)

Note that for A9 and Launchpad we wrap the stubs in `() => void` functions, so we can defer their execution without using a dynamic import.

## Why?

Collect more of our vendor third party code in one place. Make it clearer that this should remain as JavaScript.
