### PR TITLE
chore: Remove npm suggestion from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@
 yarn add @guardian/commercial-core
 ```
 
-or
-
-```bash
-npm install @guardian/commercial-core
-```
-
 ### Bundling
 
 This package uses `ES2020`.


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Remove npm install suggestion from readme

## Why?
We shouldn't encourage using a package manager other than yarn as the `yarn.lock` file won't be read or written to, and could cause inconsistent dependencies.

