### PR TITLE
feat: YouTube IMA AdTag builder

### DIFF
--- a/src/ad-targeting-youtube.ts
+++ b/src/ad-targeting-youtube.ts
@@ -1,8 +1,11 @@
+import type { Participations } from '@guardian/ab-core';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { getCookie } from '@guardian/libs';
 import { canUseDom } from './lib/can-use-dom';
 import { constructQuery } from './lib/construct-query';
 import { getPermutivePFPSegments } from './permutive';
+import { filterEmptyValues } from './targeting/build-page-targeting';
+import { experimentsTargeting } from './targeting/session';
 import type {
 	AdsConfig,
 	AdsConfigBasic,
@@ -118,17 +121,22 @@ const encodeVastTagKeyValues = (
 const buildImaAdTagUrl = (
 	adUnit: string,
 	customParams: CustomParams,
+	clientSideParticipations: Participations,
 ): string => {
+	console.log(clientSideParticipations);
 	const customParameters = {
+		ab: experimentsTargeting({
+			clientSideParticipations,
+			serverSideParticipations: window.guardian.config.tests ?? {},
+		}),
 		...customParams,
 		...buildCustomParamsFromCookies(),
 	};
-	// const customParameters = { at: 'fixed-puppies' };
 	console.log('raw cust params', customParameters);
 
 	const queryParams = {
-		// iu: adUnit,
-		iu: '/59666047/theguardian.com',
+		iu: adUnit,
+		// iu: '/59666047/theguardian.com',
 		description_url: '[placeholder]', // do we need this?
 		tfcd: '0',
 		npa: '0',
@@ -140,8 +148,10 @@ const buildImaAdTagUrl = (
 		impl: 's',
 		correlator: '', // do we need this?
 		vad_type: 'linear',
-		// vpos: 'preroll',
-		cust_params: encodeVastTagKeyValues(customParameters),
+		vpos: 'preroll',
+		cust_params: encodeVastTagKeyValues(
+			filterEmptyValues(customParameters),
+		),
 	};
 
 	console.log(queryParams);

--- a/src/ad-targeting-youtube.ts
+++ b/src/ad-targeting-youtube.ts
@@ -89,4 +89,71 @@ const buildAdsConfigWithConsent = (
 	return buildAdsConfig(consentState, adUnit, customParamsToMerge);
 };
 
-export { buildAdsConfigWithConsent, disabledAds };
+/**
+ * @param  {Record<string, MaybeArray<string|number|boolean>>
+ * do this https://support.google.com/admanager/answer/1080597
+ */
+const encodeVastTagKeyValues = (
+	query: Record<string, MaybeArray<string | number | boolean>>,
+): string => {
+	const unencodedUrl = Object.entries(query)
+		.map(([key, value]) => {
+			let queryValue: string;
+			if (Array.isArray(value)) {
+				queryValue = value.join(',');
+			} else if (typeof value == 'boolean' || typeof value == 'number') {
+				queryValue = value.toString();
+			} else {
+				queryValue = value;
+			}
+			return `${key}=${queryValue}`;
+		})
+		.join('&');
+	return unencodedUrl
+		.replace(/=/g, '%3D')
+		.replace(/&/g, '%26')
+		.replace(/,/g, '%2C');
+};
+
+const buildImaAdTagUrl = (
+	adUnit: string,
+	customParams: CustomParams,
+): string => {
+	const customParameters = {
+		...customParams,
+		...buildCustomParamsFromCookies(),
+	};
+	// const customParameters = { at: 'fixed-puppies' };
+	console.log('raw cust params', customParameters);
+
+	const queryParams = {
+		// iu: adUnit,
+		iu: '/59666047/theguardian.com',
+		description_url: '[placeholder]', // do we need this?
+		tfcd: '0',
+		npa: '0',
+		sz: '480x360|480x361|400x300',
+		gdfp_req: '1',
+		output: 'vast',
+		unviewed_position_start: '1',
+		env: 'vp',
+		impl: 's',
+		correlator: '', // do we need this?
+		vad_type: 'linear',
+		// vpos: 'preroll',
+		cust_params: encodeVastTagKeyValues(customParameters),
+	};
+
+	console.log(queryParams);
+
+	const queryParamsArray = [];
+	for (const [k, v] of Object.entries(queryParams)) {
+		queryParamsArray.push(`${k}=${v}`);
+	}
+	return (
+		'https://pubads.g.doubleclick.net/gampad/live/ads?' +
+		queryParamsArray.join('&')
+	);
+};
+
+export { buildAdsConfigWithConsent, buildImaAdTagUrl, disabledAds };

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,11 @@ export {
 export { initTrackScrollDepth } from './track-scroll-depth';
 export { initTrackLabsContainer } from './track-labs-container';
 export { initTrackGpcSignal } from './track-gpc-signal';
-export { buildAdsConfigWithConsent, disabledAds } from './ad-targeting-youtube';
+export {
+	buildAdsConfigWithConsent,
+	buildImaAdTagUrl,
+	disabledAds,
+} from './ad-targeting-youtube';
 export { createAdSlot, concatSizeMappings } from './create-ad-slot';
 export type {
 	AdsConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,11 +38,7 @@ export {
 export { initTrackScrollDepth } from './track-scroll-depth';
 export { initTrackLabsContainer } from './track-labs-container';
 export { initTrackGpcSignal } from './track-gpc-signal';
-export {
-	buildAdsConfigWithConsent,
-	buildImaAdTagUrl,
-	disabledAds,
-} from './ad-targeting-youtube';
+export { buildAdsConfigWithConsent, disabledAds } from './ad-targeting-youtube';
 export { createAdSlot, concatSizeMappings } from './create-ad-slot';
 export type {
 	AdsConfig,
@@ -78,3 +74,4 @@ export { a9Apstag } from './__vendor/a9-apstag';
 export { ipsosMoriStub } from './__vendor/ipsos-mori';
 export { launchpad } from './__vendor/launchpad';
 export { pubmatic } from './__vendor/pubmatic';
+export { buildImaAdTagUrl } from './targeting/youtube-ima';

--- a/src/targeting/build-page-targeting.ts
+++ b/src/targeting/build-page-targeting.ts
@@ -51,7 +51,7 @@ type PageTargeting = PartialWithNulls<
 	} & SharedTargeting
 >;
 
-const filterEmptyValues = (pageTargets: Record<string, unknown>) => {
+const filterValues = (pageTargets: Record<string, unknown>) => {
 	const filtered: Record<string, string | string[]> = {};
 	for (const key in pageTargets) {
 		const value = pageTargets[key];
@@ -131,11 +131,11 @@ const buildPageTargeting = (
 		...viewportTargeting,
 	};
 
-	// filter out empty values
-	const pageTargeting = filterEmptyValues(pageTargets);
+	// filter !(string | string[]) and empty values
+	const pageTargeting = filterValues(pageTargets);
 
 	return pageTargeting;
 };
 
-export { buildPageTargeting, filterEmptyValues };
+export { buildPageTargeting, filterValues };
 export type { PageTargeting };

--- a/src/targeting/build-page-targeting.ts
+++ b/src/targeting/build-page-targeting.ts
@@ -137,5 +137,5 @@ const buildPageTargeting = (
 	return pageTargeting;
 };
 
-export { buildPageTargeting };
+export { buildPageTargeting, filterEmptyValues };
 export type { PageTargeting };

--- a/src/targeting/session.ts
+++ b/src/targeting/session.ts
@@ -184,4 +184,4 @@ const getSessionTargeting = ({
 });
 
 export type { SessionTargeting, AllParticipations };
-export { getSessionTargeting };
+export { getSessionTargeting, experimentsTargeting };

--- a/src/targeting/youtube-ima.spec.ts
+++ b/src/targeting/youtube-ima.spec.ts
@@ -2,23 +2,21 @@ import { buildImaAdTagUrl } from './youtube-ima';
 
 describe('Builds an IMA ad tag URL', () => {
 	it('default values and empty custom parameters', () => {
-		const adTagURL = buildImaAdTagUrl('someAdUnit', {}, {});
+		const adTagURL = buildImaAdTagUrl('someAdUnit', {});
 		expect(adTagURL).toEqual(
 			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=',
 		);
 	});
 	it('default values and encoded custom parameters', () => {
-		const adTagURL = buildImaAdTagUrl(
-			'someAdUnit',
-			{
-				testParam1: 'hello1',
-				testParam2: 'hello2',
-				testParam3: ['hello3', 'hello4'],
-			},
-			{},
-		);
+		const adTagURL = buildImaAdTagUrl('someAdUnit', {
+			param1: 'hello1',
+			param2: 'hello2',
+			param3: ['hello3', 'hello4'],
+			param4: true, // not a string so filtered out by filterValues
+			param5: 5, // not a string so filtered out by filterValues
+		});
 		expect(adTagURL).toEqual(
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=testParam1%3Dhello1%26testParam2%3Dhello2%26testParam3%3Dhello3%2Chello4',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%2Chello4',
 		);
 	});
 });

--- a/src/targeting/youtube-ima.spec.ts
+++ b/src/targeting/youtube-ima.spec.ts
@@ -4,7 +4,7 @@ describe('Builds an IMA ad tag URL', () => {
 	it('default values and empty custom parameters', () => {
 		const adTagURL = buildImaAdTagUrl('someAdUnit', {});
 		expect(adTagURL).toEqual(
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=at%3Dfixed-puppies',
 		);
 	});
 	it('default values and encoded custom parameters', () => {
@@ -16,7 +16,7 @@ describe('Builds an IMA ad tag URL', () => {
 			param5: 5, // not a string so filtered out by filterValues
 		});
 		expect(adTagURL).toEqual(
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%2Chello4',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%2Chello4%26at%3Dfixed-puppies',
 		);
 	});
 });

--- a/src/targeting/youtube-ima.spec.ts
+++ b/src/targeting/youtube-ima.spec.ts
@@ -1,0 +1,24 @@
+import { buildImaAdTagUrl } from './youtube-ima';
+
+describe('Builds an IMA ad tag URL', () => {
+	it('default values and empty custom parameters', () => {
+		const adTagURL = buildImaAdTagUrl('someAdUnit', {}, {});
+		expect(adTagURL).toEqual(
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=',
+		);
+	});
+	it('default values and encoded custom parameters', () => {
+		const adTagURL = buildImaAdTagUrl(
+			'someAdUnit',
+			{
+				testParam1: 'hello1',
+				testParam2: 'hello2',
+				testParam3: ['hello3', 'hello4'],
+			},
+			{},
+		);
+		expect(adTagURL).toEqual(
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=testParam1%3Dhello1%26testParam2%3Dhello2%26testParam3%3Dhello3%2Chello4',
+		);
+	});
+});

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -1,24 +1,18 @@
-import type { Participations } from '@guardian/ab-core';
 import type { CustomParams, MaybeArray } from '../types';
-import { filterEmptyValues } from './build-page-targeting';
+import { filterValues } from './build-page-targeting';
 
 /**
  * @param  {Record<string, MaybeArray<string|number|boolean>>
- * do this https://support.google.com/admanager/answer/1080597
+ * Follows https://support.google.com/admanager/answer/1080597
  */
 const encodeVastTagKeyValues = (
-	query: Record<string, MaybeArray<string | number | boolean>>,
+	query: Record<string, MaybeArray<string>>,
 ): string => {
 	const unencodedUrl = Object.entries(query)
 		.map(([key, value]) => {
-			let queryValue: string;
-			if (Array.isArray(value)) {
-				queryValue = value.join(',');
-			} else if (typeof value == 'boolean' || typeof value == 'number') {
-				queryValue = String(value);
-			} else {
-				queryValue = value;
-			}
+			const queryValue = Array.isArray(value)
+				? value.join(',')
+				: String(value);
 			return `${key}=${queryValue}`;
 		})
 		.join('&');
@@ -31,7 +25,7 @@ const encodeVastTagKeyValues = (
 const buildImaAdTagUrl = (
 	adUnit: string,
 	customParams: CustomParams,
-	clientSideParticipations: Participations,
+	// TODO: clientSideParticipations: Participations,
 ): string => {
 	const queryParams = {
 		iu: adUnit,
@@ -47,7 +41,7 @@ const buildImaAdTagUrl = (
 		correlator: '', // do we need this?
 		vad_type: 'linear',
 		vpos: 'preroll',
-		cust_params: encodeVastTagKeyValues(filterEmptyValues(customParams)),
+		cust_params: encodeVastTagKeyValues(filterValues(customParams)),
 	};
 
 	const queryParamsArray = [];

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -25,8 +25,11 @@ const encodeVastTagKeyValues = (
 const buildImaAdTagUrl = (
 	adUnit: string,
 	customParams: CustomParams,
-	// TODO: clientSideParticipations: Participations,
 ): string => {
+	// TODO: Add regular build-page-targeting to
+	// get all targeting including ab participations.
+	// For now hardcode adtest (at)
+	const mergedCustomParams = { ...customParams, at: 'fixed-puppies' };
 	const queryParams = {
 		iu: adUnit,
 		description_url: '[placeholder]', // do we need this?
@@ -41,7 +44,7 @@ const buildImaAdTagUrl = (
 		correlator: '', // do we need this?
 		vad_type: 'linear',
 		vpos: 'preroll',
-		cust_params: encodeVastTagKeyValues(filterValues(customParams)),
+		cust_params: encodeVastTagKeyValues(filterValues(mergedCustomParams)),
 	};
 
 	const queryParamsArray = [];

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -15,7 +15,7 @@ const encodeVastTagKeyValues = (
 			if (Array.isArray(value)) {
 				queryValue = value.join(',');
 			} else if (typeof value == 'boolean' || typeof value == 'number') {
-				queryValue = value.toString();
+				queryValue = String(value);
 			} else {
 				queryValue = value;
 			}
@@ -55,7 +55,7 @@ const buildImaAdTagUrl = (
 		queryParamsArray.push(`${k}=${v}`);
 	}
 	return (
-		'https://pubads.g.doubleclick.net/gampad/live/ads?' +
+		'https://pubads.g.doubleclick.net/gampad/ads?' +
 		queryParamsArray.join('&')
 	);
 };

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -1,0 +1,63 @@
+import type { Participations } from '@guardian/ab-core';
+import type { CustomParams, MaybeArray } from '../types';
+import { filterEmptyValues } from './build-page-targeting';
+
+/**
+ * @param  {Record<string, MaybeArray<string|number|boolean>>
+ * do this https://support.google.com/admanager/answer/1080597
+ */
+const encodeVastTagKeyValues = (
+	query: Record<string, MaybeArray<string | number | boolean>>,
+): string => {
+	const unencodedUrl = Object.entries(query)
+		.map(([key, value]) => {
+			let queryValue: string;
+			if (Array.isArray(value)) {
+				queryValue = value.join(',');
+			} else if (typeof value == 'boolean' || typeof value == 'number') {
+				queryValue = value.toString();
+			} else {
+				queryValue = value;
+			}
+			return `${key}=${queryValue}`;
+		})
+		.join('&');
+	return unencodedUrl
+		.replace(/=/g, '%3D')
+		.replace(/&/g, '%26')
+		.replace(/,/g, '%2C');
+};
+
+const buildImaAdTagUrl = (
+	adUnit: string,
+	customParams: CustomParams,
+	clientSideParticipations: Participations,
+): string => {
+	const queryParams = {
+		iu: adUnit,
+		description_url: '[placeholder]', // do we need this?
+		tfcd: '0',
+		npa: '0',
+		sz: '480x360|480x361|400x300',
+		gdfp_req: '1',
+		output: 'vast',
+		unviewed_position_start: '1',
+		env: 'vp',
+		impl: 's',
+		correlator: '', // do we need this?
+		vad_type: 'linear',
+		vpos: 'preroll',
+		cust_params: encodeVastTagKeyValues(filterEmptyValues(customParams)),
+	};
+
+	const queryParamsArray = [];
+	for (const [k, v] of Object.entries(queryParams)) {
+		queryParamsArray.push(`${k}=${v}`);
+	}
+	return (
+		'https://pubads.g.doubleclick.net/gampad/live/ads?' +
+		queryParamsArray.join('&')
+	);
+};
+
+export { buildImaAdTagUrl };


### PR DESCRIPTION
## What does this change?

Adds a utility function `buildImaAdTagUrl` for our YouTube IMA ads integration.

Once we have full targeting in commercial-core (coming soon) we will update to use that. For the moment this is a foundational piece of work to shift the building of the ad tag from DCR into commercial-core

## Why?

This will construct an ad tag URL to be used by the YouTube IMA ads integration.
