### PR TITLE
feat: add `youtube` parameter to `buildPageTargeting`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export {
 export { initTrackScrollDepth } from './track-scroll-depth';
 export { initTrackLabsContainer } from './track-labs-container';
 export { initTrackGpcSignal } from './track-gpc-signal';
-export { buildAdsConfigWithConsent, disabledAds } from './ad-targeting-youtube';
+export { buildAdsConfigWithConsent, disabledAds } from './targeting/youtube';
 export { createAdSlot, concatSizeMappings } from './create-ad-slot';
 export type {
 	AdsConfig,

--- a/src/targeting/build-page-targeting-consentless.ts
+++ b/src/targeting/build-page-targeting-consentless.ts
@@ -47,10 +47,10 @@ const buildPageTargetingConsentless = (
 	consentState: ConsentState,
 	adFree: boolean,
 ): ConsentlessPageTargeting => {
-	const consentedPageTargeting: PageTargeting = buildPageTargeting(
+	const consentedPageTargeting: PageTargeting = buildPageTargeting({
 		consentState,
 		adFree,
-	);
+	});
 
 	return Object.fromEntries(
 		Object.entries(consentedPageTargeting).filter(([k]) =>

--- a/src/targeting/build-page-targeting.spec.ts
+++ b/src/targeting/build-page-targeting.spec.ts
@@ -164,6 +164,7 @@ describe('Build Page Targeting', () => {
 	afterEach(() => {
 		jest.spyOn(global.Math, 'random').mockRestore();
 		jest.resetAllMocks();
+		storage.local.clear();
 	});
 
 	it('should exist', () => {
@@ -171,7 +172,10 @@ describe('Build Page Targeting', () => {
 	});
 
 	it('should build correct page targeting', () => {
-		const pageTargeting = buildPageTargeting(emptyConsent, false);
+		const pageTargeting = buildPageTargeting({
+			consentState: emptyConsent,
+			adFree: false,
+		});
 
 		expect(pageTargeting.sens).toBe('f');
 		expect(pageTargeting.edition).toBe('us');
@@ -192,62 +196,130 @@ describe('Build Page Targeting', () => {
 	});
 
 	it('should set correct personalized ad (pa) param', () => {
-		expect(buildPageTargeting(tcfv2WithConsentMock, false).pa).toBe('t');
-		expect(buildPageTargeting(tcfv2WithoutConsentMock, false).pa).toBe('f');
-		expect(buildPageTargeting(tcfv2NullConsentMock, false).pa).toBe('f');
-		expect(buildPageTargeting(tcfv2MixedConsentMock, false).pa).toBe('f');
-		expect(buildPageTargeting(ccpaWithConsentMock, false).pa).toBe('t');
-		expect(buildPageTargeting(ccpaWithoutConsentMock, false).pa).toBe('f');
+		expect(
+			buildPageTargeting({
+				consentState: tcfv2WithConsentMock,
+				adFree: false,
+			}).pa,
+		).toBe('t');
+		expect(
+			buildPageTargeting({
+				consentState: tcfv2WithoutConsentMock,
+				adFree: false,
+			}).pa,
+		).toBe('f');
+		expect(
+			buildPageTargeting({
+				consentState: tcfv2NullConsentMock,
+				adFree: false,
+			}).pa,
+		).toBe('f');
+		expect(
+			buildPageTargeting({
+				consentState: tcfv2MixedConsentMock,
+				adFree: false,
+			}).pa,
+		).toBe('f');
+		expect(
+			buildPageTargeting({
+				consentState: ccpaWithConsentMock,
+				adFree: false,
+			}).pa,
+		).toBe('t');
+		expect(
+			buildPageTargeting({
+				consentState: ccpaWithoutConsentMock,
+				adFree: false,
+			}).pa,
+		).toBe('f');
 	});
 
 	it('Should correctly set the RDP flag (rdp) param', () => {
-		expect(buildPageTargeting(tcfv2WithoutConsentMock, false).rdp).toBe(
-			'na',
-		);
-		expect(buildPageTargeting(tcfv2NullConsentMock, false).rdp).toBe('na');
-		expect(buildPageTargeting(ccpaWithConsentMock, false).rdp).toBe('f');
-		expect(buildPageTargeting(ccpaWithoutConsentMock, false).rdp).toBe('t');
+		expect(
+			buildPageTargeting({
+				consentState: tcfv2WithoutConsentMock,
+				adFree: false,
+			}).rdp,
+		).toBe('na');
+		expect(
+			buildPageTargeting({
+				consentState: tcfv2NullConsentMock,
+				adFree: false,
+			}).rdp,
+		).toBe('na');
+		expect(
+			buildPageTargeting({
+				consentState: ccpaWithConsentMock,
+				adFree: false,
+			}).rdp,
+		).toBe('f');
+		expect(
+			buildPageTargeting({
+				consentState: ccpaWithoutConsentMock,
+				adFree: false,
+			}).rdp,
+		).toBe('t');
 	});
 
 	it('Should correctly set the TCFv2 (consent_tcfv2, cmp_interaction) params', () => {
 		expect(
-			buildPageTargeting(tcfv2WithConsentMock, false).consent_tcfv2,
+			buildPageTargeting({
+				consentState: tcfv2WithConsentMock,
+				adFree: false,
+			}).consent_tcfv2,
 		).toBe('t');
 		expect(
-			buildPageTargeting(tcfv2WithConsentMock, false).cmp_interaction,
+			buildPageTargeting({
+				consentState: tcfv2WithConsentMock,
+				adFree: false,
+			}).cmp_interaction,
 		).toBe('useractioncomplete');
 
 		expect(
-			buildPageTargeting(tcfv2WithoutConsentMock, false).consent_tcfv2,
+			buildPageTargeting({
+				consentState: tcfv2WithoutConsentMock,
+				adFree: false,
+			}).consent_tcfv2,
 		).toBe('f');
 		expect(
-			buildPageTargeting(tcfv2WithoutConsentMock, false).cmp_interaction,
+			buildPageTargeting({
+				consentState: tcfv2WithoutConsentMock,
+				adFree: false,
+			}).cmp_interaction,
 		).toBe('cmpuishown');
 
 		expect(
-			buildPageTargeting(tcfv2MixedConsentMock, false).consent_tcfv2,
+			buildPageTargeting({
+				consentState: tcfv2MixedConsentMock,
+				adFree: false,
+			}).consent_tcfv2,
 		).toBe('f');
 		expect(
-			buildPageTargeting(tcfv2MixedConsentMock, false).cmp_interaction,
+			buildPageTargeting({
+				consentState: tcfv2MixedConsentMock,
+				adFree: false,
+			}).cmp_interaction,
 		).toBe('useractioncomplete');
 	});
 
 	it('should set correct edition param', () => {
-		expect(buildPageTargeting(emptyConsent, false).edition).toBe('us');
+		expect(
+			buildPageTargeting({ consentState: emptyConsent, adFree: false })
+				.edition,
+		).toBe('us');
 	});
 
 	it('should set correct se param', () => {
-		expect(buildPageTargeting(emptyConsent, false).se).toEqual([
-			'filmweekly',
-		]);
+		expect(
+			buildPageTargeting({ consentState: emptyConsent, adFree: false })
+				.se,
+		).toEqual(['filmweekly']);
 	});
 
 	it('should set correct k param', () => {
-		expect(buildPageTargeting(emptyConsent, false).k).toEqual([
-			'prince-charles-letters',
-			'uk/uk',
-			'prince-charles',
-		]);
+		expect(
+			buildPageTargeting({ consentState: emptyConsent, adFree: false }).k,
+		).toEqual(['prince-charles-letters', 'uk/uk', 'prince-charles']);
 	});
 
 	it.only('should set correct ab param', () => {
@@ -255,21 +327,31 @@ describe('Build Page Targeting', () => {
 			MtMaster: { variant: 'variantName' },
 		});
 
-		expect(buildPageTargeting(emptyConsent, false).ab).toEqual([
-			'MtMaster-variantName',
-		]);
+		expect(
+			buildPageTargeting({ consentState: emptyConsent, adFree: false })
+				.ab,
+		).toEqual(['MtMaster-variantName']);
 	});
 
 	it('should set Observer flag for Observer content', () => {
-		expect(buildPageTargeting(emptyConsent, false).ob).toEqual('t');
+		expect(
+			buildPageTargeting({ consentState: emptyConsent, adFree: false })
+				.ob,
+		).toEqual('t');
 	});
 
 	it('should set correct branding param for paid content', () => {
-		expect(buildPageTargeting(emptyConsent, false).br).toEqual('p');
+		expect(
+			buildPageTargeting({ consentState: emptyConsent, adFree: false })
+				.br,
+		).toEqual('p');
 	});
 
 	it('should not contain an ad-free targeting value', () => {
-		expect(buildPageTargeting(emptyConsent, false).af).toBeUndefined();
+		expect(
+			buildPageTargeting({ consentState: emptyConsent, adFree: false })
+				.af,
+		).toBeUndefined();
 	});
 
 	it('should remove empty values', () => {
@@ -279,7 +361,9 @@ describe('Build Page Targeting', () => {
 		} as unknown as typeof window.guardian.config.page;
 		window.guardian.config.ophan = { pageViewId: '123456' };
 
-		expect(buildPageTargeting(emptyConsent, false)).toEqual({
+		expect(
+			buildPageTargeting({ consentState: emptyConsent, adFree: false }),
+		).toEqual({
 			at: 'ng101',
 			bp: 'mobile',
 			cc: 'US',
@@ -302,113 +386,177 @@ describe('Build Page Targeting', () => {
 	describe('Breakpoint targeting', () => {
 		it('should set correct breakpoint targeting for a mobile device', () => {
 			mockViewport(320, 0);
-			expect(buildPageTargeting(emptyConsent, false).bp).toEqual(
-				'mobile',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).bp,
+			).toEqual('mobile');
 		});
 
 		it('should set correct breakpoint targeting for a medium mobile device', () => {
 			mockViewport(375, 0);
-			expect(buildPageTargeting(emptyConsent, false).bp).toEqual(
-				'mobile',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).bp,
+			).toEqual('mobile');
 		});
 
 		it('should set correct breakpoint targeting for a mobile device in landscape mode', () => {
 			mockViewport(480, 0);
-			expect(buildPageTargeting(emptyConsent, false).bp).toEqual(
-				'mobile',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).bp,
+			).toEqual('mobile');
 		});
 
 		it('should set correct breakpoint targeting for a phablet device', () => {
 			mockViewport(660, 0);
-			expect(buildPageTargeting(emptyConsent, false).bp).toEqual(
-				'tablet',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).bp,
+			).toEqual('tablet');
 		});
 
 		it('should set correct breakpoint targeting for a tablet device', () => {
 			mockViewport(740, 0);
-			expect(buildPageTargeting(emptyConsent, false).bp).toEqual(
-				'tablet',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).bp,
+			).toEqual('tablet');
 		});
 
 		it('should set correct breakpoint targeting for a desktop device', () => {
 			mockViewport(980, 0);
-			expect(buildPageTargeting(emptyConsent, false).bp).toEqual(
-				'desktop',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).bp,
+			).toEqual('desktop');
 		});
 
 		it('should set correct breakpoint targeting for a leftCol device', () => {
 			mockViewport(1140, 0);
-			expect(buildPageTargeting(emptyConsent, false).bp).toEqual(
-				'desktop',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).bp,
+			).toEqual('desktop');
 		});
 
 		it('should set correct breakpoint targeting for a wide device', () => {
 			mockViewport(1300, 0);
-			expect(buildPageTargeting(emptyConsent, false).bp).toEqual(
-				'desktop',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).bp,
+			).toEqual('desktop');
 		});
 	});
 
 	describe('Build Page Targeting (ad-free)', () => {
 		it('should set the ad-free param to t when enabled', () => {
-			expect(buildPageTargeting(emptyConsent, true).af).toBe('t');
+			expect(
+				buildPageTargeting({ consentState: emptyConsent, adFree: true })
+					.af,
+			).toBe('t');
+		});
+	});
+
+	describe('Permutive', () => {
+		it('should set the permutive param to the value from localstorage', () => {
+			const PERMUTIVE_KEY = `_papns`;
+			storage.local.setRaw(PERMUTIVE_KEY, '[1, 2, 3]');
+
+			expect(
+				buildPageTargeting({
+					consentState: ccpaWithConsentMock,
+					adFree: false,
+				}).permutive,
+			).toEqual(['1', '2', '3']);
 		});
 	});
 
 	describe('Already visited frequency', () => {
 		it('can pass a value of five or less', () => {
 			storage.local.setRaw('gu.alreadyVisited', String(5));
-			expect(buildPageTargeting(ccpaWithConsentMock, false).fr).toEqual(
-				'5',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: ccpaWithConsentMock,
+					adFree: false,
+				}).fr,
+			).toEqual('5');
 		});
 
 		it('between five and thirty, includes it in a bucket in the form "x-y"', () => {
 			storage.local.setRaw('gu.alreadyVisited', String(18));
-			expect(buildPageTargeting(ccpaWithConsentMock, false).fr).toEqual(
-				'16-19',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: ccpaWithConsentMock,
+					adFree: false,
+				}).fr,
+			).toEqual('16-19');
 		});
 
 		it('over thirty, includes it in the bucket "30plus"', () => {
 			storage.local.setRaw('gu.alreadyVisited', String(300));
-			expect(buildPageTargeting(ccpaWithConsentMock, false).fr).toEqual(
-				'30plus',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: ccpaWithConsentMock,
+					adFree: false,
+				}).fr,
+			).toEqual('30plus');
 		});
 
 		it('passes a value of 0 if the value is not stored', () => {
 			storage.local.remove('gu.alreadyVisited');
-			expect(buildPageTargeting(ccpaWithConsentMock, false).fr).toEqual(
-				'0',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: ccpaWithConsentMock,
+					adFree: false,
+				}).fr,
+			).toEqual('0');
 		});
 
 		it('passes a value of 0 if the number is invalid', () => {
 			storage.local.setRaw('gu.alreadyVisited', 'not-a-number');
-			expect(buildPageTargeting(ccpaWithConsentMock, false).fr).toEqual(
-				'0',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: ccpaWithConsentMock,
+					adFree: false,
+				}).fr,
+			).toEqual('0');
 		});
 
 		it('passes a value of 0 if consent is not given', () => {
 			storage.local.setRaw('gu.alreadyVisited', String(5));
 			expect(
-				buildPageTargeting(ccpaWithoutConsentMock, false).fr,
+				buildPageTargeting({
+					consentState: ccpaWithoutConsentMock,
+					adFree: false,
+				}).fr,
 			).toEqual('0');
 		});
 
 		it('passes a value of 0 if empty consent', () => {
 			storage.local.setRaw('gu.alreadyVisited', String(5));
-			expect(buildPageTargeting(emptyConsent, false).fr).toEqual('0');
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).fr,
+			).toEqual('0');
 		});
 	});
 
@@ -417,59 +565,82 @@ describe('Build Page Targeting', () => {
 			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
 				'https://www.facebook.com/feel-the-force',
 			);
-			expect(buildPageTargeting(emptyConsent, false).ref).toEqual(
-				'facebook',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).ref,
+			).toEqual('facebook');
 		});
 
 		it('should set ref to Twitter', () => {
 			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
 				'https://t.co/you-must-unlearn-what-you-have-learned',
 			);
-			expect(buildPageTargeting(emptyConsent, false).ref).toEqual(
-				'twitter',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).ref,
+			).toEqual('twitter');
 		});
 
 		it('should set ref to reddit', () => {
 			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
 				'https://www.reddit.com/its-not-my-fault',
 			);
-			expect(buildPageTargeting(emptyConsent, false).ref).toEqual(
-				'reddit',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).ref,
+			).toEqual('reddit');
 		});
 
 		it('should set ref to google', () => {
 			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
 				'https://www.google.com/i-find-your-lack-of-faith-distrubing',
 			);
-			expect(buildPageTargeting(emptyConsent, false).ref).toEqual(
-				'google',
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).ref,
+			).toEqual('google');
 		});
 
 		it('should set ref empty string if referrer does not match', () => {
 			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
 				'https://theguardian.com',
 			);
-			expect(buildPageTargeting(emptyConsent, false).ref).toEqual(
-				undefined,
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).ref,
+			).toEqual(undefined);
 		});
 	});
 
 	describe('URL Keywords', () => {
 		it('should return correct keywords from pageId', () => {
-			expect(buildPageTargeting(emptyConsent, false).urlkw).toEqual([
-				'footballweekly',
-			]);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).urlkw,
+			).toEqual(['footballweekly']);
 		});
 
 		it('should extract multiple url keywords correctly', () => {
 			window.guardian.config.page.pageId =
 				'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london';
-			expect(buildPageTargeting(emptyConsent, false).urlkw).toEqual([
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).urlkw,
+			).toEqual([
 				'harry',
 				'potter',
 				'cursed',
@@ -484,7 +655,12 @@ describe('Build Page Targeting', () => {
 		it('should get correct keywords when trailing slash is present', () => {
 			window.guardian.config.page.pageId =
 				'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
-			expect(buildPageTargeting(emptyConsent, false).urlkw).toEqual([
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).urlkw,
+			).toEqual([
 				'harry',
 				'potter',
 				'cursed',
@@ -502,14 +678,24 @@ describe('Build Page Targeting', () => {
 			cmp.hasInitialised.mockReturnValue(false);
 			cmp.willShowPrivacyMessageSync.mockReturnValue(false);
 			mockViewport(1920, 1080);
-			expect(buildPageTargeting(emptyConsent, false).inskin).toBe('f');
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).inskin,
+			).toBe('f');
 		});
 
 		it('should not allow inskin if cmp will show a banner', () => {
 			cmp.hasInitialised.mockReturnValue(true);
 			cmp.willShowPrivacyMessageSync.mockReturnValue(true);
 			mockViewport(1920, 1080);
-			expect(buildPageTargeting(emptyConsent, false).inskin).toBe('f');
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).inskin,
+			).toBe('f');
 		});
 	});
 
@@ -526,14 +712,22 @@ describe('Build Page Targeting', () => {
 			cmp.hasInitialised.mockReturnValue(true);
 			cmp.willShowPrivacyMessageSync.mockReturnValue(false);
 			mockViewport(width, 800);
-			expect(buildPageTargeting(emptyConsent, false).skinsize).toBe(
-				expected,
-			);
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).skinsize,
+			).toBe(expected);
 		});
 
 		it("should return 's' if vp does not have a width", () => {
 			mockViewport(0, 0);
-			expect(buildPageTargeting(emptyConsent, false).skinsize).toBe('s');
+			expect(
+				buildPageTargeting({
+					consentState: emptyConsent,
+					adFree: false,
+				}).skinsize,
+			).toBe('s');
 		});
 	});
 
@@ -542,7 +736,10 @@ describe('Build Page Targeting', () => {
 		it('if present in localstorage, use value from storage', () => {
 			storage.local.setRaw(STORAGE_KEY, '10');
 			expect(
-				buildPageTargeting(tcfv2WithConsentMock, false).amtgrp,
+				buildPageTargeting({
+					consentState: tcfv2WithConsentMock,
+					adFree: false,
+				}).amtgrp,
 			).toEqual('10');
 			storage.local.remove(STORAGE_KEY);
 		});
@@ -560,19 +757,22 @@ describe('Build Page Targeting', () => {
 			[tcfv2MixedConsentMock, undefined],
 		])('Framework %p => amtgrp is %s', (consentState, value) => {
 			storage.local.setRaw(STORAGE_KEY, '9');
-			expect(buildPageTargeting(consentState, false).amtgrp).toEqual(
-				value,
-			);
+			expect(
+				buildPageTargeting({
+					consentState: consentState,
+					adFree: false,
+				}).amtgrp,
+			).toEqual(value);
 			storage.local.remove(STORAGE_KEY);
 		});
 
 		it('if not present in localstorage, generate a random group 1-12, store in localstorage', () => {
 			// restore Math.random for this test so we can assert the group value range is 1-12
 			jest.spyOn(global.Math, 'random').mockRestore();
-			const valueGenerated = buildPageTargeting(
-				tcfv2WithConsentMock,
-				false,
-			).amtgrp;
+			const valueGenerated = buildPageTargeting({
+				consentState: tcfv2WithConsentMock,
+				adFree: false,
+			}).amtgrp;
 			expect(valueGenerated).toBeDefined();
 			expect(Number(valueGenerated)).toBeGreaterThanOrEqual(1);
 			expect(Number(valueGenerated)).toBeLessThanOrEqual(12);

--- a/src/targeting/build-page-targeting.spec.ts
+++ b/src/targeting/build-page-targeting.spec.ts
@@ -322,7 +322,7 @@ describe('Build Page Targeting', () => {
 		).toEqual(['prince-charles-letters', 'uk/uk', 'prince-charles']);
 	});
 
-	it.only('should set correct ab param', () => {
+	it('should set correct ab param', () => {
 		storage.local.set('gu.ab.participations', {
 			MtMaster: { variant: 'variantName' },
 		});

--- a/src/targeting/build-page-targeting.ts
+++ b/src/targeting/build-page-targeting.ts
@@ -68,10 +68,17 @@ const filterValues = (pageTargets: Record<string, unknown>) => {
 	return filtered;
 };
 
-const buildPageTargeting = (
-	consentState: ConsentState,
-	adFree: boolean,
-): PageTargeting => {
+type BuildPageTargetingParams = {
+	consentState: ConsentState;
+	adFree: boolean;
+	youtube?: boolean;
+};
+
+const buildPageTargeting = ({
+	consentState,
+	adFree,
+	youtube = false,
+}: BuildPageTargetingParams): Record<string, string | string[]> => {
 	const { page, isDotcomRendering } = window.guardian.config;
 
 	const adFreeTargeting: { af?: True } = adFree ? { af: 't' } : {};
@@ -120,7 +127,10 @@ const buildPageTargeting = (
 		? getSharedTargeting(page.sharedAdTargeting)
 		: {};
 
-	const personalisedTargeting = getPersonalisedTargeting(consentState);
+	const personalisedTargeting = getPersonalisedTargeting({
+		state: consentState,
+		youtube,
+	});
 
 	const pageTargets: PageTargeting = {
 		...personalisedTargeting,

--- a/src/targeting/personalised.spec.ts
+++ b/src/targeting/personalised.spec.ts
@@ -33,7 +33,10 @@ describe('Personalised targeting', () => {
 				rdp: 'na',
 				fr: '1',
 			};
-			const targeting = getPersonalisedTargeting(tcfv2WithFullConsent);
+			const targeting = getPersonalisedTargeting({
+				state: tcfv2WithFullConsent,
+				youtube: false,
+			});
 			expect(targeting).toMatchObject(expected);
 		});
 
@@ -61,7 +64,10 @@ describe('Personalised targeting', () => {
 				rdp: 'na',
 				fr: '0',
 			};
-			const targeting = getPersonalisedTargeting(tcfv2WithoutConsent);
+			const targeting = getPersonalisedTargeting({
+				state: tcfv2WithoutConsent,
+				youtube: false,
+			});
 			expect(targeting).toMatchObject(expected);
 		});
 	});
@@ -82,7 +88,7 @@ describe('Personalised targeting', () => {
 				rdp: 'f',
 				fr: '4',
 			};
-			const targeting = getPersonalisedTargeting(state);
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
 			expect(targeting).toMatchObject(expected);
 		});
 
@@ -101,7 +107,7 @@ describe('Personalised targeting', () => {
 				rdp: 't',
 				fr: '0',
 			};
-			const targeting = getPersonalisedTargeting(state);
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
 			expect(targeting).toMatchObject(expected);
 		});
 	});
@@ -122,7 +128,7 @@ describe('Personalised targeting', () => {
 				rdp: 'na',
 				fr: '10-15',
 			};
-			const targeting = getPersonalisedTargeting(state);
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
 			expect(targeting).toMatchObject(expected);
 		});
 
@@ -141,7 +147,7 @@ describe('Personalised targeting', () => {
 				rdp: 'na',
 				fr: '0',
 			};
-			const targeting = getPersonalisedTargeting(state);
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
 			expect(targeting).toMatchObject(expected);
 		});
 	});
@@ -186,7 +192,7 @@ describe('Personalised targeting', () => {
 				rdp: 'f',
 				fr,
 			};
-			const targeting = getPersonalisedTargeting(state);
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
 			expect(targeting).toMatchObject(expected);
 		});
 	});
@@ -227,7 +233,7 @@ describe('Personalised targeting', () => {
 				rdp: 'f',
 				amtgrp,
 			};
-			const targeting = getPersonalisedTargeting(state);
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
 			expect(targeting).toMatchObject(expected);
 
 			mockRandom.mockRestore();
@@ -244,7 +250,7 @@ describe('Personalised targeting', () => {
 
 			storage.local.set(AMTGRP_STORAGE_KEY, '1');
 
-			const targeting = getPersonalisedTargeting(state);
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
 
 			expect(targeting.amtgrp).toBeNull();
 			expect(storage.local.get(AMTGRP_STORAGE_KEY)).toBeNull();
@@ -257,7 +263,7 @@ describe('Personalised targeting', () => {
 				framework: 'ccpa',
 			};
 
-			const targeting = getPersonalisedTargeting(state);
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
 			expect(targeting.amtgrp).not.toBeNull();
 		});
 
@@ -268,8 +274,40 @@ describe('Personalised targeting', () => {
 				framework: 'aus',
 			};
 
-			const targeting = getPersonalisedTargeting(state);
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
 			expect(targeting.amtgrp).not.toBeNull();
+		});
+	});
+	describe('Permutive', () => {
+		const PERMUTIVE_KEY = `_papns`;
+		const PERMUTIVE_PFP_KEY = `_pdfps`;
+
+		test('Should set `permutive` to correct values if `youtube` is set to false', () => {
+			const state: ConsentState = {
+				ccpa: { doNotSell: false },
+				canTarget: true,
+				framework: 'ccpa',
+			};
+
+			storage.local.setRaw(PERMUTIVE_KEY, '[1, 2, 3]');
+			storage.local.setRaw(PERMUTIVE_PFP_KEY, '[]');
+
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
+			expect(targeting.permutive).toEqual(['1', '2', '3']);
+		});
+
+		test('Should set `permutive` to correct values if `youtube` is set to true', () => {
+			const state: ConsentState = {
+				ccpa: { doNotSell: false },
+				canTarget: true,
+				framework: 'ccpa',
+			};
+
+			storage.local.setRaw(PERMUTIVE_KEY, '[]');
+			storage.local.setRaw(PERMUTIVE_PFP_KEY, '[4, 5, 6]');
+
+			const targeting = getPersonalisedTargeting({ state, youtube: true });
+			expect(targeting.permutive).toEqual(['4', '5', '6']);
 		});
 	});
 
@@ -290,7 +328,7 @@ describe('Personalised targeting', () => {
 				consent_tcfv2: 'na',
 				rdp: 'na',
 			};
-			const targeting = getPersonalisedTargeting(state);
+			const targeting = getPersonalisedTargeting({ state, youtube: false });
 
 			expect(targeting).toMatchObject(expected);
 			expect(storage.local.get(AMTGRP_STORAGE_KEY)).toBeNull();

--- a/src/targeting/personalised.ts
+++ b/src/targeting/personalised.ts
@@ -1,7 +1,11 @@
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { TCEventStatusCode } from '@guardian/consent-management-platform/dist/types/tcfv2';
 import { storage } from '@guardian/libs';
-import { clearPermutiveSegments, getPermutiveSegments } from '../permutive';
+import {
+	clearPermutiveSegments,
+	getPermutivePFPSegments,
+	getPermutiveSegments,
+} from '../permutive';
 import type { False, NotApplicable, True } from '../types';
 
 /* -- Types -- */
@@ -226,8 +230,10 @@ const getAdManagerGroup = (
 		: createAdManagerGroup();
 };
 
-const getPermutiveWithState = (state: ConsentState) => {
-	if (state.canTarget) return getPermutiveSegments();
+const getPermutiveWithState = (state: ConsentState, youtube: boolean) => {
+	if (state.canTarget) {
+		return youtube ? getPermutivePFPSegments() : getPermutiveSegments();
+	}
 
 	clearPermutiveSegments();
 	return [];
@@ -235,12 +241,18 @@ const getPermutiveWithState = (state: ConsentState) => {
 
 /* -- Targeting -- */
 
-const getPersonalisedTargeting = (
-	state: ConsentState,
-): PersonalisedTargeting => ({
+type Personalised = {
+	state: ConsentState;
+	youtube: boolean;
+};
+
+const getPersonalisedTargeting = ({
+	state,
+	youtube,
+}: Personalised): PersonalisedTargeting => ({
 	amtgrp: getAdManagerGroup(state),
 	fr: getFrequencyValue(state),
-	permutive: getPermutiveWithState(state),
+	permutive: getPermutiveWithState(state, youtube),
 	...getCMPTargeting(state),
 });
 

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -27,7 +27,10 @@ const mergeCustomParamsWithTargeting = (
 ) => {
 	let pageTargeting = {};
 	try {
-		pageTargeting = buildPageTargeting(consentState, false);
+		pageTargeting = buildPageTargeting({
+			consentState: consentState,
+			adFree: false,
+		});
 	} catch (e) {
 		/**
 		 * Defensive error handling in case YoutubeAtom is used in an

--- a/src/targeting/youtube.ts
+++ b/src/targeting/youtube.ts
@@ -1,8 +1,5 @@
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
-import { getCookie } from '@guardian/libs';
-import { canUseDom } from './lib/can-use-dom';
-import { constructQuery } from './lib/construct-query';
-import { getPermutivePFPSegments } from './permutive';
+import { constructQuery } from '../lib/construct-query';
 import type {
 	AdsConfig,
 	AdsConfigBasic,
@@ -10,17 +7,10 @@ import type {
 	AdsConfigDisabled,
 	AdsConfigTCFV2,
 	CustomParams,
-} from './types';
+} from '../types';
+import { buildPageTargeting } from './build-page-targeting';
 
 const disabledAds: AdsConfigDisabled = { disableAds: true };
-
-const buildCustomParamsFromCookies = (): CustomParams =>
-	canUseDom()
-		? {
-				permutive: getPermutivePFPSegments(),
-				si: getCookie({ name: 'GU_U' }) ? 't' : 'f',
-		  }
-		: {};
 
 const buildAdsConfig = (
 	cmpConsent: ConsentState,
@@ -29,7 +19,11 @@ const buildAdsConfig = (
 ): AdsConfig => {
 	const mergedCustomParams = {
 		...customParams,
-		...buildCustomParamsFromCookies(),
+		...buildPageTargeting({
+			consentState: cmpConsent,
+			adFree: false,
+			youtube: true,
+		}),
 	};
 
 	const defaultAdsConfig: AdsConfigBasic = {


### PR DESCRIPTION
## What does this change?

When `youtube` is set to `false`, `buildPageTargeting` pulls the regular permutive segments (i.e. those stored in localstorage under the key `_papns`). This was the default behaviour before this change.

When `youtube` is set to `true`, `buildPageTargeting` pulls the youtube-specific permutive segments (i.e. those stored in localstorage under the key `_pdfps`)

## Why?

So we can finally start using `buildPageTargeting` in `buildAdsConfig`, which happens in [this commit](https://github.com/guardian/commercial-core/pull/708/commits/260f96ff78ab9d4789c64ad4be05bc5e25e8b5d1).