### PR TITLE
feat: YouTube IMA ad tag URL uses page targeting

### DIFF
--- a/src/targeting/youtube-ima.spec.ts
+++ b/src/targeting/youtube-ima.spec.ts
@@ -1,22 +1,41 @@
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { buildPageTargeting } from './build-page-targeting';
 import { buildImaAdTagUrl } from './youtube-ima';
+
+jest.mock('./build-page-targeting', () => ({
+	// we want the real filterValues()
+	...jest.requireActual('./build-page-targeting'),
+	buildPageTargeting: jest.fn(),
+}));
+
+const emptyConsent: ConsentState = {
+	canTarget: false,
+	framework: null,
+};
 
 describe('Builds an IMA ad tag URL', () => {
 	it('default values and empty custom parameters', () => {
-		const adTagURL = buildImaAdTagUrl('someAdUnit', {});
+		(buildPageTargeting as jest.Mock).mockReturnValue({
+			at: 'adTestValue',
+		})
+		const adTagURL = buildImaAdTagUrl('someAdUnit', {}, emptyConsent);
 		expect(adTagURL).toEqual(
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=at%3Dfixed-puppies',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=at%3DadTestValue',
 		);
 	});
 	it('default values and encoded custom parameters', () => {
+		(buildPageTargeting as jest.Mock).mockReturnValue({
+			at: 'adTestValue',
+		})
 		const adTagURL = buildImaAdTagUrl('someAdUnit', {
 			param1: 'hello1',
 			param2: 'hello2',
 			param3: ['hello3', 'hello4'],
 			param4: true, // not a string so filtered out by filterValues
 			param5: 5, // not a string so filtered out by filterValues
-		});
+		}, emptyConsent);
 		expect(adTagURL).toEqual(
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%2Chello4%26at%3Dfixed-puppies',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%2Chello4%26at%3DadTestValue',
 		);
 	});
 });

--- a/src/targeting/youtube-ima.spec.ts
+++ b/src/targeting/youtube-ima.spec.ts
@@ -25,18 +25,21 @@ describe('Builds an IMA ad tag URL', () => {
 	});
 	it('default values and encoded custom parameters', () => {
 		(buildPageTargeting as jest.Mock).mockReturnValue({
-			at: 'adTestValue',
+			at: 'fixed-puppies',
 			encodeMe: '=&,'
 		})
-		const adTagURL = buildImaAdTagUrl('someAdUnit', {
+		const adTagURL = buildImaAdTagUrl('/59666047/theguardian.com', {
 			param1: 'hello1',
 			param2: 'hello2',
 			param3: ['hello3', 'hello4'],
 			param4: true, // not a string so filtered out by filterValues
 			param5: 5, // not a string so filtered out by filterValues
+			param6: '=&,',
 		}, emptyConsent);
 		expect(adTagURL).toEqual(
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26at%3DadTestValue%26encodeMe%3D%253D%2526%252C',
+			// this is a real ad tag url that you can paste into Google's VAST tag checker:
+			// https://googleads.github.io/googleads-ima-html5/vsi/
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
 		);
 	});
 });

--- a/src/targeting/youtube-ima.spec.ts
+++ b/src/targeting/youtube-ima.spec.ts
@@ -20,7 +20,7 @@ describe('Builds an IMA ad tag URL', () => {
 		})
 		const adTagURL = buildImaAdTagUrl('someAdUnit', {}, emptyConsent);
 		expect(adTagURL).toEqual(
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=at%3DadTestValue',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=at%3DadTestValue',
 		);
 	});
 	it('default values and encoded custom parameters', () => {
@@ -39,7 +39,7 @@ describe('Builds an IMA ad tag URL', () => {
 		expect(adTagURL).toEqual(
 			// this is a real ad tag url that you can paste into Google's VAST tag checker:
 			// https://googleads.github.io/googleads-ima-html5/vsi/
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
 		);
 	});
 });

--- a/src/targeting/youtube-ima.spec.ts
+++ b/src/targeting/youtube-ima.spec.ts
@@ -26,6 +26,7 @@ describe('Builds an IMA ad tag URL', () => {
 	it('default values and encoded custom parameters', () => {
 		(buildPageTargeting as jest.Mock).mockReturnValue({
 			at: 'adTestValue',
+			encodeMe: '=&,'
 		})
 		const adTagURL = buildImaAdTagUrl('someAdUnit', {
 			param1: 'hello1',
@@ -35,7 +36,7 @@ describe('Builds an IMA ad tag URL', () => {
 			param5: 5, // not a string so filtered out by filterValues
 		}, emptyConsent);
 		expect(adTagURL).toEqual(
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%2Chello4%26at%3DadTestValue',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&description_url=[placeholder]&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26at%3DadTestValue%26encodeMe%3D%253D%2526%252C',
 		);
 	});
 });

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -1,5 +1,6 @@
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { CustomParams, MaybeArray } from '../types';
-import { filterValues } from './build-page-targeting';
+import { buildPageTargeting, filterValues } from './build-page-targeting';
 
 /**
  * @param  {Record<string, MaybeArray<string|number|boolean>>
@@ -25,11 +26,11 @@ const encodeVastTagKeyValues = (
 const buildImaAdTagUrl = (
 	adUnit: string,
 	customParams: CustomParams,
+	consentState: ConsentState,
 ): string => {
-	// TODO: Add regular build-page-targeting to
-	// get all targeting including ab participations.
-	// For now hardcode adtest (at)
-	const mergedCustomParams = { ...customParams, at: 'fixed-puppies' };
+	const pageTargeting = buildPageTargeting(consentState, false);
+	const mergedCustomParams = { ...customParams, ...pageTargeting };
+
 	const queryParams = {
 		iu: adUnit,
 		description_url: '[placeholder]', // do we need this?

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -6,21 +6,18 @@ import { buildPageTargeting, filterValues } from './build-page-targeting';
  * @param  {Record<string, MaybeArray<string|number|boolean>>
  * Follows https://support.google.com/admanager/answer/1080597
  */
-const encodeVastTagKeyValues = (
-	query: Record<string, MaybeArray<string>>,
+const encodeCustomParams = (
+	params: Record<string, MaybeArray<string>>,
 ): string => {
-	const unencodedUrl = Object.entries(query)
+	const encodedParams = Object.entries(params)
 		.map(([key, value]) => {
 			const queryValue = Array.isArray(value)
 				? value.join(',')
 				: String(value);
-			return `${key}=${queryValue}`;
+			return `${key}=${encodeURIComponent(queryValue)}`;
 		})
 		.join('&');
-	return unencodedUrl
-		.replace(/=/g, '%3D')
-		.replace(/&/g, '%26')
-		.replace(/,/g, '%2C');
+	return encodedParams;
 };
 
 const buildImaAdTagUrl = (
@@ -45,7 +42,12 @@ const buildImaAdTagUrl = (
 		correlator: '', // do we need this?
 		vad_type: 'linear',
 		vpos: 'preroll',
-		cust_params: encodeVastTagKeyValues(filterValues(mergedCustomParams)),
+		/**
+		 * cust_params string is encoded
+		 * cust_params values are also encoded so they will get double encoded
+		 * this ensures any values with separator chars (=&,) do not conflict with main string
+		 */
+		cust_params: encodeURIComponent(encodeCustomParams(filterValues(mergedCustomParams))),
 	};
 
 	const queryParamsArray = [];

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -30,7 +30,6 @@ const buildImaAdTagUrl = (
 
 	const queryParams = {
 		iu: adUnit,
-		description_url: '[placeholder]', // do we need this?
 		tfcd: '0',
 		npa: '0',
 		sz: '480x360|480x361|400x300',
@@ -39,13 +38,12 @@ const buildImaAdTagUrl = (
 		unviewed_position_start: '1',
 		env: 'vp',
 		impl: 's',
-		correlator: '', // do we need this?
 		vad_type: 'linear',
 		vpos: 'preroll',
 		/**
 		 * cust_params string is encoded
 		 * cust_params values are also encoded so they will get double encoded
-		 * this ensures any values with separator chars (=&,) do not conflict with main string
+		 * this ensures any values with separator chars (=&,) do not conflict with the main string
 		 */
 		cust_params: encodeURIComponent(encodeCustomParams(filterValues(mergedCustomParams))),
 	};


### PR DESCRIPTION
## What does this change?

Updates `youtube-ima` to use  regular `getPageTargeting` in order to build a full targeting object to pass to GAM.

Primarily concerned with adtest (at) and ab test participations (ab) but the other targeting will be useful when IMA ads are up and running.

## Why?

We can target YouTube IMA ads more effectively.
