### PR TITLE
feat: YouTube IMA handles exceptions from build-page-targeting

### DIFF
--- a/src/targeting/youtube-ima.spec.ts
+++ b/src/targeting/youtube-ima.spec.ts
@@ -23,7 +23,7 @@ describe('Builds an IMA ad tag URL', () => {
 			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=at%3DadTestValue',
 		);
 	});
-	it('default values and encoded custom parameters', () => {
+	it('encodes custom parameters', () => {
 		(buildPageTargeting as jest.Mock).mockReturnValue({
 			at: 'fixed-puppies',
 			encodeMe: '=&,'
@@ -40,6 +40,17 @@ describe('Builds an IMA ad tag URL', () => {
 			// this is a real ad tag url that you can paste into Google's VAST tag checker:
 			// https://googleads.github.io/googleads-ima-html5/vsi/
 			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
+		);
+	});
+	it('uses provided custom parameters if page targeting throws an exception', () => {
+		(buildPageTargeting as jest.Mock).mockImplementation(() => {
+			throw new Error("Error from page targeting!");
+		});
+		const adTagURL = buildImaAdTagUrl('/59666047/theguardian.com', {
+			param1: 'hello1',
+		}, emptyConsent);
+		expect(adTagURL).toEqual(
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1',
 		);
 	});
 });

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -1,4 +1,5 @@
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { log } from '@guardian/libs';
 import type { CustomParams, MaybeArray } from '../types';
 import { buildPageTargeting, filterValues } from './build-page-targeting';
 
@@ -20,14 +21,34 @@ const encodeCustomParams = (
 	return encodedParams;
 };
 
+const mergeCustomParamsWithTargeting = (
+	customParams: CustomParams,
+	consentState: ConsentState,
+) => {
+	try {
+		const pageTargeting = buildPageTargeting(consentState, false);
+		const mergedCustomParams = { ...customParams, ...pageTargeting };
+		return mergedCustomParams;
+	} catch (e) {
+		/**
+		 * Defensive error handling in case YoutubeAtom is used in an
+		 * environment where guardian.config, cookies, localstorage etc
+		 * is not available
+		 */
+		log('commercial', 'Error building YouTube IMA custom params', e);
+	}
+	return customParams;
+};
+
 const buildImaAdTagUrl = (
 	adUnit: string,
 	customParams: CustomParams,
 	consentState: ConsentState,
 ): string => {
-	const pageTargeting = buildPageTargeting(consentState, false);
-	const mergedCustomParams = { ...customParams, ...pageTargeting };
-
+	const mergedCustomParams = mergeCustomParamsWithTargeting(
+		customParams,
+		consentState,
+	);
 	const queryParams = {
 		iu: adUnit,
 		tfcd: '0',
@@ -45,7 +66,9 @@ const buildImaAdTagUrl = (
 		 * cust_params values are also encoded so they will get double encoded
 		 * this ensures any values with separator chars (=&,) do not conflict with the main string
 		 */
-		cust_params: encodeURIComponent(encodeCustomParams(filterValues(mergedCustomParams))),
+		cust_params: encodeURIComponent(
+			encodeCustomParams(filterValues(mergedCustomParams)),
+		),
 	};
 
 	const queryParamsArray = [];

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -33,7 +33,7 @@ const mergeCustomParamsWithTargeting = (
 		/**
 		 * Defensive error handling in case YoutubeAtom is used in an
 		 * environment where guardian.config, cookies, localstorage etc
-		 * is not available
+		 * are not available
 		 */
 		log('commercial', 'Error building YouTube IMA custom params', e);
 	}


### PR DESCRIPTION
## What does this change?

YouTube IMA handles exceptions from build-page-targeting

## Why?

Defensive error handling in case YoutubeAtom and therefore `buildImaAdTagUrl` is used in an environment where `guardian.config`, cookies, localstorage etc are not available.


