### PR TITLE
feat: Pass client side test participations to targeting functions

### DIFF
--- a/src/targeting/build-page-targeting-consentless.ts
+++ b/src/targeting/build-page-targeting-consentless.ts
@@ -48,8 +48,9 @@ const buildPageTargetingConsentless = (
 	adFree: boolean,
 ): ConsentlessPageTargeting => {
 	const consentedPageTargeting: PageTargeting = buildPageTargeting({
-		consentState,
 		adFree,
+		consentState,
+		clientSideParticipations: {},
 	});
 
 	return Object.fromEntries(

--- a/src/targeting/build-page-targeting.spec.ts
+++ b/src/targeting/build-page-targeting.spec.ts
@@ -173,8 +173,9 @@ describe('Build Page Targeting', () => {
 
 	it('should build correct page targeting', () => {
 		const pageTargeting = buildPageTargeting({
-			consentState: emptyConsent,
 			adFree: false,
+			clientSideParticipations: {},
+			consentState: emptyConsent,
 		});
 
 		expect(pageTargeting.sens).toBe('f');
@@ -198,38 +199,44 @@ describe('Build Page Targeting', () => {
 	it('should set correct personalized ad (pa) param', () => {
 		expect(
 			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
 				consentState: tcfv2WithConsentMock,
-				adFree: false,
 			}).pa,
 		).toBe('t');
 		expect(
 			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
 				consentState: tcfv2WithoutConsentMock,
-				adFree: false,
 			}).pa,
 		).toBe('f');
 		expect(
 			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
 				consentState: tcfv2NullConsentMock,
-				adFree: false,
 			}).pa,
 		).toBe('f');
 		expect(
 			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
 				consentState: tcfv2MixedConsentMock,
-				adFree: false,
 			}).pa,
 		).toBe('f');
 		expect(
 			buildPageTargeting({
-				consentState: ccpaWithConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: ccpaWithConsentMock,
 			}).pa,
 		).toBe('t');
 		expect(
 			buildPageTargeting({
-				consentState: ccpaWithoutConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: ccpaWithoutConsentMock,
 			}).pa,
 		).toBe('f');
 	});
@@ -237,26 +244,30 @@ describe('Build Page Targeting', () => {
 	it('Should correctly set the RDP flag (rdp) param', () => {
 		expect(
 			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
 				consentState: tcfv2WithoutConsentMock,
-				adFree: false,
 			}).rdp,
 		).toBe('na');
 		expect(
 			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
 				consentState: tcfv2NullConsentMock,
-				adFree: false,
 			}).rdp,
 		).toBe('na');
 		expect(
 			buildPageTargeting({
-				consentState: ccpaWithConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: ccpaWithConsentMock,
 			}).rdp,
 		).toBe('f');
 		expect(
 			buildPageTargeting({
-				consentState: ccpaWithoutConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: ccpaWithoutConsentMock,
 			}).rdp,
 		).toBe('t');
 	});
@@ -264,93 +275,121 @@ describe('Build Page Targeting', () => {
 	it('Should correctly set the TCFv2 (consent_tcfv2, cmp_interaction) params', () => {
 		expect(
 			buildPageTargeting({
-				consentState: tcfv2WithConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: tcfv2WithConsentMock,
 			}).consent_tcfv2,
 		).toBe('t');
 		expect(
 			buildPageTargeting({
-				consentState: tcfv2WithConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: tcfv2WithConsentMock,
 			}).cmp_interaction,
 		).toBe('useractioncomplete');
 
 		expect(
 			buildPageTargeting({
-				consentState: tcfv2WithoutConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: tcfv2WithoutConsentMock,
 			}).consent_tcfv2,
 		).toBe('f');
 		expect(
 			buildPageTargeting({
-				consentState: tcfv2WithoutConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: tcfv2WithoutConsentMock,
 			}).cmp_interaction,
 		).toBe('cmpuishown');
 
 		expect(
 			buildPageTargeting({
-				consentState: tcfv2MixedConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: tcfv2MixedConsentMock,
 			}).consent_tcfv2,
 		).toBe('f');
 		expect(
 			buildPageTargeting({
-				consentState: tcfv2MixedConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: tcfv2MixedConsentMock,
 			}).cmp_interaction,
 		).toBe('useractioncomplete');
 	});
 
 	it('should set correct edition param', () => {
 		expect(
-			buildPageTargeting({ consentState: emptyConsent, adFree: false })
-				.edition,
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+			}).edition,
 		).toBe('us');
 	});
 
 	it('should set correct se param', () => {
 		expect(
-			buildPageTargeting({ consentState: emptyConsent, adFree: false })
-				.se,
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+			}).se,
 		).toEqual(['filmweekly']);
 	});
 
 	it('should set correct k param', () => {
 		expect(
-			buildPageTargeting({ consentState: emptyConsent, adFree: false }).k,
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+			}).k,
 		).toEqual(['prince-charles-letters', 'uk/uk', 'prince-charles']);
 	});
 
 	it('should set correct ab param', () => {
-		storage.local.set('gu.ab.participations', {
-			MtMaster: { variant: 'variantName' },
-		});
-
 		expect(
-			buildPageTargeting({ consentState: emptyConsent, adFree: false })
-				.ab,
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {
+					MtMaster: {
+						variant: 'variantName',
+					},
+				},
+				consentState: emptyConsent,
+			}).ab,
 		).toEqual(['MtMaster-variantName']);
 	});
 
 	it('should set Observer flag for Observer content', () => {
 		expect(
-			buildPageTargeting({ consentState: emptyConsent, adFree: false })
-				.ob,
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+			}).ob,
 		).toEqual('t');
 	});
 
 	it('should set correct branding param for paid content', () => {
 		expect(
-			buildPageTargeting({ consentState: emptyConsent, adFree: false })
-				.br,
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+			}).br,
 		).toEqual('p');
 	});
 
 	it('should not contain an ad-free targeting value', () => {
 		expect(
-			buildPageTargeting({ consentState: emptyConsent, adFree: false })
-				.af,
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+			}).af,
 		).toBeUndefined();
 	});
 
@@ -362,7 +401,11 @@ describe('Build Page Targeting', () => {
 		window.guardian.config.ophan = { pageViewId: '123456' };
 
 		expect(
-			buildPageTargeting({ consentState: emptyConsent, adFree: false }),
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+			}),
 		).toEqual({
 			at: 'ng101',
 			bp: 'mobile',
@@ -388,8 +431,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(320, 0);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).bp,
 			).toEqual('mobile');
 		});
@@ -398,8 +442,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(375, 0);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).bp,
 			).toEqual('mobile');
 		});
@@ -408,8 +453,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(480, 0);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).bp,
 			).toEqual('mobile');
 		});
@@ -418,8 +464,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(660, 0);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).bp,
 			).toEqual('tablet');
 		});
@@ -428,8 +475,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(740, 0);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).bp,
 			).toEqual('tablet');
 		});
@@ -438,8 +486,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(980, 0);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).bp,
 			).toEqual('desktop');
 		});
@@ -448,8 +497,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(1140, 0);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).bp,
 			).toEqual('desktop');
 		});
@@ -458,8 +508,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(1300, 0);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).bp,
 			).toEqual('desktop');
 		});
@@ -468,8 +519,11 @@ describe('Build Page Targeting', () => {
 	describe('Build Page Targeting (ad-free)', () => {
 		it('should set the ad-free param to t when enabled', () => {
 			expect(
-				buildPageTargeting({ consentState: emptyConsent, adFree: true })
-					.af,
+				buildPageTargeting({
+					adFree: true,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
+				}).af,
 			).toBe('t');
 		});
 	});
@@ -481,8 +535,9 @@ describe('Build Page Targeting', () => {
 
 			expect(
 				buildPageTargeting({
-					consentState: ccpaWithConsentMock,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: ccpaWithConsentMock,
 				}).permutive,
 			).toEqual(['1', '2', '3']);
 		});
@@ -493,8 +548,9 @@ describe('Build Page Targeting', () => {
 			storage.local.setRaw('gu.alreadyVisited', String(5));
 			expect(
 				buildPageTargeting({
-					consentState: ccpaWithConsentMock,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: ccpaWithConsentMock,
 				}).fr,
 			).toEqual('5');
 		});
@@ -503,8 +559,9 @@ describe('Build Page Targeting', () => {
 			storage.local.setRaw('gu.alreadyVisited', String(18));
 			expect(
 				buildPageTargeting({
-					consentState: ccpaWithConsentMock,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: ccpaWithConsentMock,
 				}).fr,
 			).toEqual('16-19');
 		});
@@ -513,8 +570,9 @@ describe('Build Page Targeting', () => {
 			storage.local.setRaw('gu.alreadyVisited', String(300));
 			expect(
 				buildPageTargeting({
-					consentState: ccpaWithConsentMock,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: ccpaWithConsentMock,
 				}).fr,
 			).toEqual('30plus');
 		});
@@ -523,8 +581,9 @@ describe('Build Page Targeting', () => {
 			storage.local.remove('gu.alreadyVisited');
 			expect(
 				buildPageTargeting({
-					consentState: ccpaWithConsentMock,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: ccpaWithConsentMock,
 				}).fr,
 			).toEqual('0');
 		});
@@ -533,8 +592,9 @@ describe('Build Page Targeting', () => {
 			storage.local.setRaw('gu.alreadyVisited', 'not-a-number');
 			expect(
 				buildPageTargeting({
-					consentState: ccpaWithConsentMock,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: ccpaWithConsentMock,
 				}).fr,
 			).toEqual('0');
 		});
@@ -543,8 +603,9 @@ describe('Build Page Targeting', () => {
 			storage.local.setRaw('gu.alreadyVisited', String(5));
 			expect(
 				buildPageTargeting({
-					consentState: ccpaWithoutConsentMock,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: ccpaWithoutConsentMock,
 				}).fr,
 			).toEqual('0');
 		});
@@ -553,8 +614,9 @@ describe('Build Page Targeting', () => {
 			storage.local.setRaw('gu.alreadyVisited', String(5));
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).fr,
 			).toEqual('0');
 		});
@@ -567,8 +629,9 @@ describe('Build Page Targeting', () => {
 			);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).ref,
 			).toEqual('facebook');
 		});
@@ -579,8 +642,9 @@ describe('Build Page Targeting', () => {
 			);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).ref,
 			).toEqual('twitter');
 		});
@@ -591,8 +655,9 @@ describe('Build Page Targeting', () => {
 			);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).ref,
 			).toEqual('reddit');
 		});
@@ -603,8 +668,9 @@ describe('Build Page Targeting', () => {
 			);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).ref,
 			).toEqual('google');
 		});
@@ -615,8 +681,9 @@ describe('Build Page Targeting', () => {
 			);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).ref,
 			).toEqual(undefined);
 		});
@@ -626,8 +693,9 @@ describe('Build Page Targeting', () => {
 		it('should return correct keywords from pageId', () => {
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).urlkw,
 			).toEqual(['footballweekly']);
 		});
@@ -637,8 +705,9 @@ describe('Build Page Targeting', () => {
 				'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london';
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).urlkw,
 			).toEqual([
 				'harry',
@@ -657,8 +726,9 @@ describe('Build Page Targeting', () => {
 				'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).urlkw,
 			).toEqual([
 				'harry',
@@ -680,8 +750,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(1920, 1080);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).inskin,
 			).toBe('f');
 		});
@@ -692,8 +763,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(1920, 1080);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).inskin,
 			).toBe('f');
 		});
@@ -714,8 +786,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(width, 800);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).skinsize,
 			).toBe(expected);
 		});
@@ -724,8 +797,9 @@ describe('Build Page Targeting', () => {
 			mockViewport(0, 0);
 			expect(
 				buildPageTargeting({
-					consentState: emptyConsent,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
 				}).skinsize,
 			).toBe('s');
 		});
@@ -737,8 +811,9 @@ describe('Build Page Targeting', () => {
 			storage.local.setRaw(STORAGE_KEY, '10');
 			expect(
 				buildPageTargeting({
-					consentState: tcfv2WithConsentMock,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: tcfv2WithConsentMock,
 				}).amtgrp,
 			).toEqual('10');
 			storage.local.remove(STORAGE_KEY);
@@ -759,8 +834,9 @@ describe('Build Page Targeting', () => {
 			storage.local.setRaw(STORAGE_KEY, '9');
 			expect(
 				buildPageTargeting({
-					consentState: consentState,
 					adFree: false,
+					clientSideParticipations: {},
+					consentState: consentState,
 				}).amtgrp,
 			).toEqual(value);
 			storage.local.remove(STORAGE_KEY);
@@ -770,8 +846,9 @@ describe('Build Page Targeting', () => {
 			// restore Math.random for this test so we can assert the group value range is 1-12
 			jest.spyOn(global.Math, 'random').mockRestore();
 			const valueGenerated = buildPageTargeting({
-				consentState: tcfv2WithConsentMock,
 				adFree: false,
+				clientSideParticipations: {},
+				consentState: tcfv2WithConsentMock,
 			}).amtgrp;
 			expect(valueGenerated).toBeDefined();
 			expect(Number(valueGenerated)).toBeGreaterThanOrEqual(1);

--- a/src/targeting/build-page-targeting.spec.ts
+++ b/src/targeting/build-page-targeting.spec.ts
@@ -354,13 +354,13 @@ describe('Build Page Targeting', () => {
 			buildPageTargeting({
 				adFree: false,
 				clientSideParticipations: {
-					MtMaster: {
+					someTest: {
 						variant: 'variantName',
 					},
 				},
 				consentState: emptyConsent,
 			}).ab,
-		).toEqual(['MtMaster-variantName']);
+		).toEqual(['someTest-variantName']);
 	});
 
 	it('should set Observer flag for Observer content', () => {

--- a/src/targeting/build-page-targeting.ts
+++ b/src/targeting/build-page-targeting.ts
@@ -3,7 +3,6 @@ import { cmp } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { CountryCode } from '@guardian/libs';
 import { getCookie, isString } from '@guardian/libs';
-import { getParticipationsFromLocalStorage } from '../lib/ab-localstorage';
 import { getLocale } from '../lib/get-locale';
 import type { False, True } from '../types';
 import type { ContentTargeting } from './content';

--- a/src/targeting/build-page-targeting.ts
+++ b/src/targeting/build-page-targeting.ts
@@ -1,3 +1,4 @@
+import type { Participations } from '@guardian/ab-core';
 import { cmp } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { CountryCode } from '@guardian/libs';
@@ -69,14 +70,16 @@ const filterValues = (pageTargets: Record<string, unknown>) => {
 };
 
 type BuildPageTargetingParams = {
-	consentState: ConsentState;
 	adFree: boolean;
+	clientSideParticipations: Participations;
+	consentState: ConsentState;
 	youtube?: boolean;
 };
 
 const buildPageTargeting = ({
-	consentState,
 	adFree,
+	clientSideParticipations,
+	consentState,
 	youtube = false,
 }: BuildPageTargetingParams): Record<string, string | string[]> => {
 	const { page, isDotcomRendering } = window.guardian.config;
@@ -102,7 +105,7 @@ const buildPageTargeting = ({
 		isSignedIn: !!getCookie({ name: 'GU_U' }),
 		pageViewId: window.guardian.config.ophan.pageViewId,
 		participations: {
-			clientSideParticipations: getParticipationsFromLocalStorage(),
+			clientSideParticipations,
 			serverSideParticipations: window.guardian.config.tests ?? {},
 		},
 		referrer: getReferrer(),

--- a/src/targeting/youtube-ima.spec.ts
+++ b/src/targeting/youtube-ima.spec.ts
@@ -17,8 +17,8 @@ describe('Builds an IMA ad tag URL', () => {
 	it('default values and empty custom parameters', () => {
 		(buildPageTargeting as jest.Mock).mockReturnValue({
 			at: 'adTestValue',
-		})
-		const adTagURL = buildImaAdTagUrl('someAdUnit', {}, emptyConsent);
+		});
+		const adTagURL = buildImaAdTagUrl('someAdUnit', {}, emptyConsent, {});
 		expect(adTagURL).toEqual(
 			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=at%3DadTestValue',
 		);
@@ -26,16 +26,21 @@ describe('Builds an IMA ad tag URL', () => {
 	it('encodes custom parameters', () => {
 		(buildPageTargeting as jest.Mock).mockReturnValue({
 			at: 'fixed-puppies',
-			encodeMe: '=&,'
-		})
-		const adTagURL = buildImaAdTagUrl('/59666047/theguardian.com', {
-			param1: 'hello1',
-			param2: 'hello2',
-			param3: ['hello3', 'hello4'],
-			param4: true, // not a string so filtered out by filterValues
-			param5: 5, // not a string so filtered out by filterValues
-			param6: '=&,',
-		}, emptyConsent);
+			encodeMe: '=&,',
+		});
+		const adTagURL = buildImaAdTagUrl(
+			'/59666047/theguardian.com',
+			{
+				param1: 'hello1',
+				param2: 'hello2',
+				param3: ['hello3', 'hello4'],
+				param4: true, // not a string so filtered out by filterValues
+				param5: 5, // not a string so filtered out by filterValues
+				param6: '=&,',
+			},
+			emptyConsent,
+			{},
+		);
 		expect(adTagURL).toEqual(
 			// this is a real ad tag url that you can paste into Google's VAST tag checker:
 			// https://googleads.github.io/googleads-ima-html5/vsi/
@@ -44,11 +49,16 @@ describe('Builds an IMA ad tag URL', () => {
 	});
 	it('uses provided custom parameters if page targeting throws an exception', () => {
 		(buildPageTargeting as jest.Mock).mockImplementation(() => {
-			throw new Error("Error from page targeting!");
+			throw new Error('Error from page targeting!');
 		});
-		const adTagURL = buildImaAdTagUrl('/59666047/theguardian.com', {
-			param1: 'hello1',
-		}, emptyConsent);
+		const adTagURL = buildImaAdTagUrl(
+			'/59666047/theguardian.com',
+			{
+				param1: 'hello1',
+			},
+			emptyConsent,
+			{},
+		);
 		expect(adTagURL).toEqual(
 			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1',
 		);

--- a/src/targeting/youtube-ima.spec.ts
+++ b/src/targeting/youtube-ima.spec.ts
@@ -18,7 +18,12 @@ describe('Builds an IMA ad tag URL', () => {
 		(buildPageTargeting as jest.Mock).mockReturnValue({
 			at: 'adTestValue',
 		});
-		const adTagURL = buildImaAdTagUrl('someAdUnit', {}, emptyConsent, {});
+		const adTagURL = buildImaAdTagUrl({
+			adUnit: 'someAdUnit',
+			customParams: {},
+			consentState: emptyConsent,
+			clientSideParticipations: {},
+		});
 		expect(adTagURL).toEqual(
 			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=at%3DadTestValue',
 		);
@@ -28,9 +33,9 @@ describe('Builds an IMA ad tag URL', () => {
 			at: 'fixed-puppies',
 			encodeMe: '=&,',
 		});
-		const adTagURL = buildImaAdTagUrl(
-			'/59666047/theguardian.com',
-			{
+		const adTagURL = buildImaAdTagUrl({
+			adUnit: '/59666047/theguardian.com',
+			customParams: {
 				param1: 'hello1',
 				param2: 'hello2',
 				param3: ['hello3', 'hello4'],
@@ -38,9 +43,9 @@ describe('Builds an IMA ad tag URL', () => {
 				param5: 5, // not a string so filtered out by filterValues
 				param6: '=&,',
 			},
-			emptyConsent,
-			{},
-		);
+			consentState: emptyConsent,
+			clientSideParticipations: {},
+		});
 		expect(adTagURL).toEqual(
 			// this is a real ad tag url that you can paste into Google's VAST tag checker:
 			// https://googleads.github.io/googleads-ima-html5/vsi/
@@ -51,14 +56,14 @@ describe('Builds an IMA ad tag URL', () => {
 		(buildPageTargeting as jest.Mock).mockImplementation(() => {
 			throw new Error('Error from page targeting!');
 		});
-		const adTagURL = buildImaAdTagUrl(
-			'/59666047/theguardian.com',
-			{
+		const adTagURL = buildImaAdTagUrl({
+			adUnit: '/59666047/theguardian.com',
+			customParams: {
 				param1: 'hello1',
 			},
-			emptyConsent,
-			{},
-		);
+			consentState: emptyConsent,
+			clientSideParticipations: {},
+		});
 		expect(adTagURL).toEqual(
 			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1',
 		);

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -47,12 +47,19 @@ const mergeCustomParamsWithTargeting = (
 	return mergedCustomParams;
 };
 
-const buildImaAdTagUrl = (
-	adUnit: string,
-	customParams: CustomParams,
-	consentState: ConsentState,
-	clientSideParticipations: Participations,
-): string => {
+type BuildImaAdTagUrl = {
+	adUnit: string;
+	customParams: CustomParams;
+	consentState: ConsentState;
+	clientSideParticipations: Participations;
+};
+
+const buildImaAdTagUrl = ({
+	adUnit,
+	clientSideParticipations,
+	consentState,
+	customParams,
+}: BuildImaAdTagUrl ): string => {
 	const mergedCustomParams = mergeCustomParamsWithTargeting(
 		customParams,
 		consentState,

--- a/src/targeting/youtube-ima.ts
+++ b/src/targeting/youtube-ima.ts
@@ -1,3 +1,4 @@
+import type { Participations } from '@guardian/ab-core';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { log } from '@guardian/libs';
 import type { CustomParams, MaybeArray } from '../types';
@@ -24,12 +25,14 @@ const encodeCustomParams = (
 const mergeCustomParamsWithTargeting = (
 	customParams: CustomParams,
 	consentState: ConsentState,
+	clientSideParticipations: Participations,
 ) => {
 	let pageTargeting = {};
 	try {
 		pageTargeting = buildPageTargeting({
-			consentState: consentState,
 			adFree: false,
+			clientSideParticipations,
+			consentState: consentState,
 		});
 	} catch (e) {
 		/**
@@ -48,10 +51,12 @@ const buildImaAdTagUrl = (
 	adUnit: string,
 	customParams: CustomParams,
 	consentState: ConsentState,
+	clientSideParticipations: Participations,
 ): string => {
 	const mergedCustomParams = mergeCustomParamsWithTargeting(
 		customParams,
 		consentState,
+		clientSideParticipations,
 	);
 	const queryParams = {
 		iu: adUnit,

--- a/src/targeting/youtube.spec.ts
+++ b/src/targeting/youtube.spec.ts
@@ -255,6 +255,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adUnit,
 				custParams,
 				consentState,
+				{},
 			);
 			expect(adsConfig).toEqual(expected);
 		},
@@ -271,6 +272,7 @@ describe('YouTube Ad Targeting Object when consent errors', () => {
 				framework: null,
 				canTarget: false,
 			},
+			{},
 		);
 		expect(adsConfig).toEqual({ disableAds: true });
 	});
@@ -286,6 +288,7 @@ describe('YouTube Ad Targeting Object when ad free user', () => {
 				framework: null,
 				canTarget: false,
 			},
+			{},
 		);
 		expect(adsConfig).toEqual({ disableAds: true });
 	});

--- a/src/targeting/youtube.spec.ts
+++ b/src/targeting/youtube.spec.ts
@@ -22,7 +22,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
-			custParams: {
+			customParams: {
 				param1: 'param1',
 				param2: 'param2',
 			},
@@ -48,7 +48,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
-			custParams: {
+			customParams: {
 				param1: 'param1',
 				param2: 'param2',
 			},
@@ -74,7 +74,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
-			custParams: {
+			customParams: {
 				param1: 'param1',
 				param2: 'param2',
 			},
@@ -100,7 +100,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
-			custParams: {
+			customParams: {
 				param1: 'param1',
 				param2: 'param2',
 			},
@@ -126,7 +126,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 			} as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
-			custParams: {
+			customParams: {
 				param1: 'param1',
 				param2: 'param2',
 			},
@@ -155,7 +155,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 			} as unknown as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
-			custParams: {
+			customParams: {
 				param1: 'param1',
 				param2: 'param2',
 			},
@@ -187,7 +187,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 			} as unknown as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
-			custParams: {
+			customParams: {
 				param1: 'param1',
 				param2: 'param2',
 			},
@@ -219,7 +219,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 			} as unknown as ConsentState,
 			isAdFreeUser: false,
 			adUnit: 'someAdUnit',
-			custParams: {
+			customParams: {
 				param1: 'param1',
 				param2: 'param2',
 			},
@@ -243,20 +243,20 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 			consentState,
 			isAdFreeUser,
 			adUnit,
-			custParams,
+			customParams,
 			expected,
 		}) => {
 			(buildPageTargeting as jest.Mock).mockReturnValue({
 				permutive: ['1', '2', '3'],
 				si: isSignedIn,
 			});
-			const adsConfig = buildAdsConfigWithConsent(
-				isAdFreeUser,
+			const adsConfig = buildAdsConfigWithConsent({
 				adUnit,
-				custParams,
+				clientSideParticipations: {},
 				consentState,
-				{},
-			);
+				customParams,
+				isAdFreeUser,
+			});
 			expect(adsConfig).toEqual(expected);
 		},
 	);
@@ -264,32 +264,32 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 
 describe('YouTube Ad Targeting Object when consent errors', () => {
 	test('creates disabled ads config when consent does not have any matching framework', () => {
-		const adsConfig = buildAdsConfigWithConsent(
-			false,
-			'someAdUnit',
-			{},
-			{
+		const adsConfig = buildAdsConfigWithConsent({
+			adUnit: 'someAdUnit',
+			clientSideParticipations: {},
+			consentState: {
 				framework: null,
 				canTarget: false,
 			},
-			{},
-		);
+			customParams: {},
+			isAdFreeUser: false,
+		});
 		expect(adsConfig).toEqual({ disableAds: true });
 	});
 });
 
 describe('YouTube Ad Targeting Object when ad free user', () => {
 	test('creates disabled ads config when ad free user', () => {
-		const adsConfig = buildAdsConfigWithConsent(
-			true,
-			'someAdUnit',
-			{},
-			{
+		const adsConfig = buildAdsConfigWithConsent({
+			adUnit: 'someAdUnit',
+			clientSideParticipations: {},
+			consentState: {
 				framework: null,
 				canTarget: false,
 			},
-			{},
-		);
+			customParams: {},
+			isAdFreeUser: true,
+		});
 		expect(adsConfig).toEqual({ disableAds: true });
 	});
 });

--- a/src/targeting/youtube.ts
+++ b/src/targeting/youtube.ts
@@ -1,3 +1,4 @@
+import type { Participations } from '@guardian/ab-core';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { constructQuery } from '../lib/construct-query';
 import type {
@@ -16,12 +17,14 @@ const buildAdsConfig = (
 	cmpConsent: ConsentState,
 	adUnit: string,
 	customParams: CustomParams,
+	clientSideParticipations: Participations,
 ): AdsConfig => {
 	const mergedCustomParams = {
 		...customParams,
 		...buildPageTargeting({
-			consentState: cmpConsent,
 			adFree: false,
+			clientSideParticipations,
+			consentState: cmpConsent,
 			youtube: true,
 		}),
 	};
@@ -74,11 +77,17 @@ const buildAdsConfigWithConsent = (
 	adUnit: string,
 	customParamsToMerge: CustomParams,
 	consentState: ConsentState,
+	clientSideParticipations: Participations,
 ): AdsConfig => {
 	if (isAdFreeUser) {
 		return disabledAds;
 	}
-	return buildAdsConfig(consentState, adUnit, customParamsToMerge);
+	return buildAdsConfig(
+		consentState,
+		adUnit,
+		customParamsToMerge,
+		clientSideParticipations,
+	);
 };
 
 export { buildAdsConfigWithConsent, disabledAds };

--- a/src/targeting/youtube.ts
+++ b/src/targeting/youtube.ts
@@ -72,20 +72,28 @@ const buildAdsConfig = (
 	return disabledAds;
 };
 
-const buildAdsConfigWithConsent = (
-	isAdFreeUser: boolean,
-	adUnit: string,
-	customParamsToMerge: CustomParams,
-	consentState: ConsentState,
-	clientSideParticipations: Participations,
-): AdsConfig => {
+type BuildAdsConfigWithConsent = {
+	isAdFreeUser: boolean;
+	adUnit: string;
+	customParams: CustomParams;
+	consentState: ConsentState;
+	clientSideParticipations: Participations;
+};
+
+const buildAdsConfigWithConsent = ({
+	adUnit,
+	clientSideParticipations,
+	consentState,
+	customParams,
+	isAdFreeUser,
+}: BuildAdsConfigWithConsent): AdsConfig => {
 	if (isAdFreeUser) {
 		return disabledAds;
 	}
 	return buildAdsConfig(
 		consentState,
 		adUnit,
-		customParamsToMerge,
+		customParams,
 		clientSideParticipations,
 	);
 };


### PR DESCRIPTION
## What does this change?

- adds back `clientSideParticipations` as a parameter to `build-page-targeting`.
- updates public YouTube targeting functions to accept an object rather than an array of parameters

## Why?

We previously thought we could read test participations from localstorage. This works on Frontend but the [library that DCR uses](https://github.com/guardian/ab-testing) for ab testing [does not write to localstorage](https://github.com/guardian/ab-testing#differences-of-this-library-vs-frontend-implementation).

