### PR TITLE
feat: Add `320x480` ad size

### DIFF
--- a/src/ad-sizes.test.ts
+++ b/src/ad-sizes.test.ts
@@ -1,5 +1,4 @@
 import { _, adSizes, getAdSize } from './ad-sizes';
-import type { SizeKeys } from '.';
 
 const { createAdSize } = _;
 
@@ -22,13 +21,13 @@ describe('ad sizes', () => {
 	);
 });
 
-const sizes: Array<[SizeKeys, number, number, string]> = [
+const sizes = [
 	['mpu', 300, 250, '300,250'],
 	['fluid', 0, 0, 'fluid'],
 	['googleCard', 300, 274, '300,274'],
 	['outstreamGoogleDesktop', 550, 310, '550,310'],
 	['300x600', 300, 600, '300,600'],
-];
+] as const;
 
 describe('getAdSize', () => {
 	it.each(sizes)(

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -84,8 +84,8 @@ type SizeKeys =
 	| 'outstreamDesktop'
 	| 'outstreamGoogleDesktop'
 	| 'outstreamMobile'
-	| 'picnic'
 	| 'portrait'
+	| 'portraitInterstitial'
 	| 'skyscraper';
 
 type SlotName =
@@ -125,6 +125,7 @@ const namedStandardAdSizes = {
 	portrait: createAdSize(300, 1050),
 	skyscraper: createAdSize(160, 600),
 	cascade: createAdSize(940, 230),
+	portraitInterstitial: createAdSize(320, 480),
 };
 
 const standardAdSizes = {
@@ -149,7 +150,6 @@ const proprietaryAdSizes = {
 	fluid: createAdSize(0, 0),
 	googleCard: createAdSize(300, 274),
 	outOfPage: createAdSize(1, 1),
-	picnic: createAdSize(320, 480),
 };
 
 /**
@@ -186,7 +186,7 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.mpu,
 			adSizes.googleCard,
 			adSizes.fluid,
-			adSizes.picnic,
+			adSizes.portraitInterstitial,
 		],
 		phablet: [
 			adSizes.outOfPage,

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -142,12 +142,19 @@ const outstreamSizes = {
 	outstreamMobile: createAdSize(300, 197),
 };
 
-const dfpProprietaryAdSizes = {
+/**
+ * Ad sizes commonly associated with third parties
+ */
+const proprietaryAdSizes = {
 	fluid: createAdSize(0, 0),
 	googleCard: createAdSize(300, 274),
 	outOfPage: createAdSize(1, 1),
+	picnic: createAdSize(320, 480),
 };
 
+/**
+ * Ad sizes associated with in-house formats
+ */
 const guardianProprietaryAdSizes = {
 	empty: createAdSize(2, 2),
 	fabric: createAdSize(88, 71),
@@ -161,7 +168,7 @@ const adSizes: Record<SizeKeys, AdSize> = {
 	...namedStandardAdSizes,
 	...standardAdSizes,
 	...outstreamSizes,
-	...dfpProprietaryAdSizes,
+	...proprietaryAdSizes,
 	...guardianProprietaryAdSizes,
 };
 

--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -67,6 +67,7 @@ type SizeKeys =
 	| '728x90'
 	| '970x250'
 	| 'billboard'
+	| 'cascade'
 	| 'empty'
 	| 'fabric'
 	| 'fluid'
@@ -83,9 +84,9 @@ type SizeKeys =
 	| 'outstreamDesktop'
 	| 'outstreamGoogleDesktop'
 	| 'outstreamMobile'
+	| 'picnic'
 	| 'portrait'
-	| 'skyscraper'
-	| 'cascade';
+	| 'skyscraper';
 
 type SlotName =
 	| 'right'
@@ -178,6 +179,7 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.mpu,
 			adSizes.googleCard,
 			adSizes.fluid,
+			adSizes.picnic,
 		],
 		phablet: [
 			adSizes.outOfPage,


### PR DESCRIPTION
## What does this change?

Add the `320x480` size to our set of known ad sizes.

A small amount of drive-by refactoring as well: sorting the size keys, adding some short comments, and using `as const` in the test.

## Why?

We'll need this size when we enable Picnic on mobile web.
