### PR TITLE
fix: Set targeting to not show page skins if on preview site

### DIFF
--- a/src/create-ad-slot.spec.ts
+++ b/src/create-ad-slot.spec.ts
@@ -24,6 +24,7 @@ const DEFAULT_CONFIG = {
 	ophan: { pageViewId: 'pv_id_1234567890' },
 	page: {
 		pageId: 'world/uk',
+		isPreview: false,
 		isSensitive: false,
 		section: 'uk-news',
 		videoDuration: 63,

--- a/src/event-timer.spec.ts
+++ b/src/event-timer.spec.ts
@@ -46,6 +46,7 @@ const DEFAULT_CONFIG = {
 	ophan: { pageViewId: 'pv_id_1234567890' },
 	page: {
 		pageId: 'world/uk',
+		isPreview: false,
 		isSensitive: false,
 		section: 'uk-news',
 		videoDuration: 63,

--- a/src/google-analytics.spec.ts
+++ b/src/google-analytics.spec.ts
@@ -17,6 +17,7 @@ const DEFAULT_CONFIG = {
 	ophan: { pageViewId: 'pv_id_1234567890' },
 	page: {
 		pageId: 'world/uk',
+		isPreview: false,
 		isSensitive: false,
 		section: 'uk-news',
 		videoDuration: 63,

--- a/src/targeting/viewport.spec.ts
+++ b/src/targeting/viewport.spec.ts
@@ -2,7 +2,12 @@ import type { ViewportTargeting } from './viewport';
 import { getViewportTargeting } from './viewport';
 
 describe('Viewport targeting', () => {
-	test('No CMP banner will show', () => {
+	beforeEach(() => {
+		window.guardian = {
+			config: { page: {} },
+		} as unknown as typeof window.guardian;
+	});
+	test('Do show page skins when CMP banner will NOT show', () => {
 		const expected: ViewportTargeting = {
 			bp: 'desktop',
 			inskin: 't',
@@ -15,7 +20,7 @@ describe('Viewport targeting', () => {
 		expect(targeting).toMatchObject(expected);
 	});
 
-	test('No CMP will show', () => {
+	test('Do NOT show page skins when CMP banner will show', () => {
 		const expected: ViewportTargeting = {
 			bp: 'desktop',
 			inskin: 'f',
@@ -24,6 +29,34 @@ describe('Viewport targeting', () => {
 		const targeting = getViewportTargeting({
 			viewPortWidth: 1280,
 			cmpBannerWillShow: true,
+		});
+		expect(targeting).toMatchObject(expected);
+	});
+
+	test('Do NOT show page skins when is preview', () => {
+		window.guardian.config.page.isPreview = true;
+		const expected: ViewportTargeting = {
+			bp: 'desktop',
+			inskin: 'f',
+			skinsize: 's',
+		};
+		const targeting = getViewportTargeting({
+			viewPortWidth: 1280,
+			cmpBannerWillShow: false,
+		});
+		expect(targeting).toMatchObject(expected);
+	});
+
+	test('Do show page skins when is NOT preview', () => {
+		window.guardian.config.page.isPreview = false;
+		const expected: ViewportTargeting = {
+			bp: 'desktop',
+			inskin: 't',
+			skinsize: 's',
+		};
+		const targeting = getViewportTargeting({
+			viewPortWidth: 1280,
+			cmpBannerWillShow: false,
 		});
 		expect(targeting).toMatchObject(expected);
 	});

--- a/src/targeting/viewport.ts
+++ b/src/targeting/viewport.ts
@@ -64,8 +64,9 @@ const getViewportTargeting = ({
 	viewPortWidth,
 	cmpBannerWillShow,
 }: Viewport): ViewportTargeting => {
-	// Don’t show inskin if if a privacy message will be shown
-	const inskin = cmpBannerWillShow ? 'f' : 't';
+	// Don’t show inskin if if a privacy message will be shown or on preview
+	const isPreview = window.guardian.config.page.isPreview;
+	const inskin = cmpBannerWillShow || isPreview ? 'f' : 't';
 
 	return {
 		bp: findBreakpoint(viewPortWidth),

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export type GuardianWindowConfig = {
 	};
 	page: {
 		sharedAdTargeting?: Record<string, string | string[]>;
+		isPreview: boolean;
 		isSensitive: boolean;
 		pageId: string;
 		section: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,17 +47,17 @@ export type GuardianWindowConfig = {
 	isDotcomRendering: boolean;
 	ophan: {
 		// somewhat redundant with guardian.ophan
-		pageViewId: string;
 		browserId?: string;
+		pageViewId: string;
 	};
 	page: {
-		sharedAdTargeting?: Record<string, string | string[]>;
+		edition: Edition;
 		isPreview: boolean;
 		isSensitive: boolean;
 		pageId: string;
 		section: string;
+		sharedAdTargeting?: Record<string, string | string[]>;
 		videoDuration: number;
-		edition: Edition;
 	};
 	tests?: {
 		[key: `${string}Control`]: 'control';


### PR DESCRIPTION
## What does this change?

Sets targeting `inskin: 'f'` when on the preview site

## Why?

Page skins are rendering incorrectly in preview due to not finding the correct top.window.

We decided to turn them off entirely for editorial's preview environment ( h/t @ashishpuliyel )
