### PR TITLE
fix: Use unified CMP event names

### DIFF
--- a/src/event-timer.spec.ts
+++ b/src/event-timer.spec.ts
@@ -38,8 +38,8 @@ const performance = {
 
 const MARK_NAME = 'mark_name';
 const MARK_LONG_NAME = `gu.commercial.${MARK_NAME}`;
-const CMP_INIT = 'cmp-tcfv2-init';
-const CMP_GOT_CONSENT = 'cmp-tcfv2-got-consent';
+const CMP_INIT = 'cmp-init';
+const CMP_GOT_CONSENT = 'cmp-got-consent';
 
 const DEFAULT_CONFIG = {
 	isDotcomRendering: true,

--- a/src/event-timer.ts
+++ b/src/event-timer.ts
@@ -52,15 +52,9 @@ interface EventTimerProperties {
 class EventTimer {
 	private _events: Event[];
 	private static _externallyDefinedEventNames = [
-		'cmp-tcfv2-init',
-		'cmp-tcfv2-ui-displayed',
-		'cmp-tcfv2-got-consent',
-		'cmp-ccpa-init',
-		'cmp-ccpa-ui-displayed',
-		'cmp-ccpa-got-consent',
-		'cmp-aus-init',
-		'cmp-aus-ui-displayed',
-		'cmp-aus-got-consent',
+		'cmp-init',
+		'cmp-ui-displayed',
+		'cmp-got-consent',
 	];
 	startTS: DOMHighResTimeStamp;
 	triggers: {

--- a/src/send-commercial-metrics.spec.ts
+++ b/src/send-commercial-metrics.spec.ts
@@ -546,13 +546,13 @@ describe('send commercial metrics helpers', () => {
 		expect(
 			roundTimeStamp([
 				{
-					name: 'cmp-tcfv2-init',
+					name: 'test-metric',
 					ts: 1519211809934.234,
 				},
 			]),
 		).toEqual([
 			{
-				name: 'cmp-tcfv2-init',
+				name: 'test-metric',
 				value: 1519211809935,
 			},
 		]);


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

This changes the set of externally defined event names, removing all of the existing per-framework names and using ones that are framework-agnostic.

The three new event names:
- [`cmp-init`](https://github.com/search?q=repo%3Aguardian%2Fconsent-management-platform+cmp-init&type=code)
- [`cmp-ui-displayed`](https://github.com/search?q=repo%3Aguardian%2Fconsent-management-platform+cmp-ui-displayed&type=code)
- [`cmp-got-consent`](https://github.com/search?q=repo%3Aguardian%2Fconsent-management-platform+cmp-got-consent&type=code)

## Why?

Some time ago the Consent Management Platform moved over to a ['unified implementation'](https://github.com/guardian/consent-management-platform/pull/561). In doing so, we stopped leaving the same unique performance marks for each of the three CMP frameworks. This PR moves commercial-core to start looking up the new correct marks, so we add them to our commercial metrics payload correctly.

Note there we will be some work required from the data-side to reconfigure the dashboard to use these measurements.
