### PR TITLE
fix!: Remove portrait interstitial from size mappings

### DIFF
--- a/src/ad-sizes.ts
+++ b/src/ad-sizes.ts
@@ -186,7 +186,6 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.mpu,
 			adSizes.googleCard,
 			adSizes.fluid,
-			adSizes.portraitInterstitial,
 		],
 		phablet: [
 			adSizes.outOfPage,


### PR DESCRIPTION
## What does this change?

Remove the `320x480` size from our size mappings.

## Why?

This size mapping was introduced as part of #735. We now only want to apply this size to certain inlines on articles, so we'll add it as an additional size in Frontend instead.