### PR TITLE
fix: Remove tall ads from comments section

### DIFF
--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -221,15 +221,6 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.googleCard,
 			adSizes.fluid,
 		],
-		desktop: [
-			adSizes.outOfPage,
-			adSizes.empty,
-			adSizes.mpu,
-			adSizes.googleCard,
-			adSizes.fluid,
-			adSizes.halfPage,
-			adSizes.skyscraper,
-		],
 		phablet: [
 			adSizes.outOfPage,
 			adSizes.empty,
@@ -237,6 +228,15 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.mpu,
 			adSizes.googleCard,
 			adSizes.fluid,
+		],
+		desktop: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.halfPage,
+			adSizes.mpu,
+			adSizes.googleCard,
+			adSizes.fluid,
+			adSizes.skyscraper,
 		],
 	},
 	'comments-expanded': {
@@ -285,15 +285,6 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.googleCard,
 			adSizes.fluid,
 		],
-		tablet: [
-			adSizes.outOfPage,
-			adSizes.empty,
-			adSizes.mpu,
-			adSizes.googleCard,
-			adSizes.halfPage,
-			adSizes.leaderboard,
-			adSizes.fluid,
-		],
 		phablet: [
 			adSizes.outOfPage,
 			adSizes.empty,
@@ -301,6 +292,15 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.mpu,
 			adSizes.googleCard,
 			adSizes.halfPage,
+			adSizes.fluid,
+		],
+		tablet: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.mpu,
+			adSizes.googleCard,
+			adSizes.halfPage,
+			adSizes.leaderboard,
 			adSizes.fluid,
 		],
 		desktop: [
@@ -352,8 +352,8 @@ const slotSizeMappings: SlotSizeMappings = {
 		mobile: [adSizes.mobilesticky],
 	},
 	'crossword-banner': {
-		tablet: [adSizes.outOfPage, adSizes.empty, adSizes.leaderboard],
 		phablet: [adSizes.outOfPage, adSizes.empty, adSizes.leaderboard],
+		tablet: [adSizes.outOfPage, adSizes.empty, adSizes.leaderboard],
 	},
 	exclusion: {
 		mobile: [adSizes.empty],

--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -215,7 +215,6 @@ const slotSizeMappings: SlotSizeMappings = {
 		mobile: [
 			adSizes.outOfPage,
 			adSizes.empty,
-			adSizes.halfPage,
 			adSizes.outstreamMobile,
 			adSizes.mpu,
 			adSizes.googleCard,
@@ -232,11 +231,9 @@ const slotSizeMappings: SlotSizeMappings = {
 		desktop: [
 			adSizes.outOfPage,
 			adSizes.empty,
-			adSizes.halfPage,
 			adSizes.mpu,
 			adSizes.googleCard,
 			adSizes.fluid,
-			adSizes.skyscraper,
 		],
 	},
 	'comments-expanded': {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

- Removes tall ads (skyscraper, half-page) from comments section
- Reordered breakpoints so that all are in ascending order

## Why?

There is not enough room to display a tall ad without create a large amount of whitespace, pushing the content below down. Therefore we should limit this ad slot to ad sizes that can be placed without moving the content.