### PR TITLE
feat: Add new targeting key-value `rc` ("Recently Published Content")

### DIFF
--- a/core/src/create-ad-slot.spec.ts
+++ b/core/src/create-ad-slot.spec.ts
@@ -29,6 +29,7 @@ const DEFAULT_CONFIG = {
 		section: 'uk-news',
 		videoDuration: 63,
 		edition: 'UK' as const,
+		webPublicationDate: 608857200,
 	},
 };
 

--- a/core/src/event-timer.spec.ts
+++ b/core/src/event-timer.spec.ts
@@ -51,6 +51,7 @@ const DEFAULT_CONFIG = {
 		section: 'uk-news',
 		videoDuration: 63,
 		edition: 'UK' as const,
+		webPublicationDate: 608857200,
 	},
 };
 

--- a/core/src/google-analytics.spec.ts
+++ b/core/src/google-analytics.spec.ts
@@ -22,6 +22,7 @@ const DEFAULT_CONFIG = {
 		section: 'uk-news',
 		videoDuration: 63,
 		edition: 'UK' as const,
+		webPublicationDate: 608857200,
 	},
 };
 

--- a/core/src/targeting/build-page-targeting-consentless.spec.ts
+++ b/core/src/targeting/build-page-targeting-consentless.spec.ts
@@ -42,6 +42,7 @@ describe('buildPageTargetingConsentless', () => {
 			bp: 'desktop',
 			skinsize: 's',
 			inskin: 'f',
+			rc: '0',
 		});
 
 		expect(buildPageTargetingConsentless(emptyConsent, false)).toEqual({
@@ -64,6 +65,7 @@ describe('buildPageTargetingConsentless', () => {
 			si: 't',
 			bp: 'desktop',
 			skinsize: 's',
+			rc: '0',
 		});
 	});
 });

--- a/core/src/targeting/build-page-targeting-consentless.ts
+++ b/core/src/targeting/build-page-targeting-consentless.ts
@@ -13,6 +13,7 @@ const consentlessTargetingKeys = [
 	'dcre',
 	'edition',
 	'k',
+	'rc',
 	'rp',
 	's',
 	'se',

--- a/core/src/targeting/build-page-targeting.spec.ts
+++ b/core/src/targeting/build-page-targeting.spec.ts
@@ -142,6 +142,7 @@ describe('Build Page Targeting', () => {
 						url: '/football/series/footballweekly',
 					},
 					isSensitive: false,
+					webPublicationDate: 608857200,
 				} as unknown as typeof window.guardian.config.page,
 			} as unknown as typeof window.guardian.config,
 		};

--- a/core/src/targeting/build-page-targeting.spec.ts
+++ b/core/src/targeting/build-page-targeting.spec.ts
@@ -195,6 +195,7 @@ describe('Build Page Targeting', () => {
 		expect(pageTargeting.pa).toEqual('f');
 		expect(pageTargeting.cc).toEqual('US');
 		expect(pageTargeting.rp).toEqual('dotcom-platform');
+		expect(pageTargeting.rc).toEqual('7');
 	});
 
 	it('should set correct personalized ad (pa) param', () => {
@@ -418,6 +419,7 @@ describe('Build Page Targeting', () => {
 			inskin: 'f',
 			pa: 'f',
 			pv: '123456',
+			rc: '7',
 			rdp: 'na',
 			rp: 'dotcom-platform',
 			sens: 'f',

--- a/core/src/targeting/build-page-targeting.ts
+++ b/core/src/targeting/build-page-targeting.ts
@@ -36,6 +36,7 @@ type PageTargeting = PartialWithNulls<
 		pa: TrueOrFalse; // Personalised Ads consent
 		permutive: string[]; // predefined segment values
 		pv: string; // ophan Page View id
+		rc: string; // recently published content
 		rdp: string;
 		ref: string; // REFerrer
 		rp: 'dotcom-rendering' | 'dotcom-platform'; // Rendering Platform
@@ -86,6 +87,7 @@ const buildPageTargeting = ({
 	const adFreeTargeting: { af?: True } = adFree ? { af: 't' } : {};
 
 	const contentTargeting: ContentTargeting = getContentTargeting({
+		webPublicationDate: page.webPublicationDate,
 		eligibleForDCR: isDotcomRendering,
 		path: `/${page.pageId}`,
 		renderingPlatform: isDotcomRendering

--- a/core/src/targeting/content.spec.ts
+++ b/core/src/targeting/content.spec.ts
@@ -8,6 +8,7 @@ const defaultValues: Parameters<typeof getContentTargeting>[0] = {
 	renderingPlatform: 'dotcom-platform',
 	section: 'uk-news',
 	eligibleForDCR: false,
+	webPublicationDate: 608857200,
 };
 
 describe('Content Targeting', () => {

--- a/core/src/targeting/content.spec.ts
+++ b/core/src/targeting/content.spec.ts
@@ -226,4 +226,115 @@ describe('Content Targeting', () => {
 			expect(targeting).toMatchObject(expected);
 		});
 	});
+
+	describe('Recently published content (rc)', () => {
+		// Mock Date.now to return a fixed date
+		Date.now = jest.fn(() =>
+			new Date('January 1, 2023 00:00:00').getTime(),
+		);
+
+		test('correctly buckets content published 1 second ago', () => {
+			expect(
+				getContentTargeting({
+					...defaultValues,
+					webPublicationDate: new Date(
+						'December 31, 2022 23:59:59',
+					).getTime(),
+				}),
+			).toMatchObject({
+				rc: '0',
+			});
+		});
+
+		test('correctly buckets content published 6 hours ago', () => {
+			expect(
+				getContentTargeting({
+					...defaultValues,
+					webPublicationDate: new Date(
+						'December 31, 2022 18:00:00',
+					).getTime(),
+				}),
+			).toMatchObject({
+				rc: '1',
+			});
+		});
+
+		test('correctly buckets content published 2 days ago', () => {
+			expect(
+				getContentTargeting({
+					...defaultValues,
+					webPublicationDate: new Date(
+						'December 30, 2022 00:00:00',
+					).getTime(),
+				}),
+			).toMatchObject({
+				rc: '2',
+			});
+		});
+
+		test('correctly buckets content published 5 days ago', () => {
+			expect(
+				getContentTargeting({
+					...defaultValues,
+					webPublicationDate: new Date(
+						'December 26, 2022 00:00:00',
+					).getTime(),
+				}),
+			).toMatchObject({
+				rc: '3',
+			});
+		});
+
+		test('correctly buckets content published 2 weeks ago', () => {
+			expect(
+				getContentTargeting({
+					...defaultValues,
+					webPublicationDate: new Date(
+						'December 18, 2022 00:00:00',
+					).getTime(),
+				}),
+			).toMatchObject({
+				rc: '4',
+			});
+		});
+
+		test('correctly buckets content published 6 months ago', () => {
+			expect(
+				getContentTargeting({
+					...defaultValues,
+					webPublicationDate: new Date(
+						'July 1, 2022 00:00:00',
+					).getTime(),
+				}),
+			).toMatchObject({
+				rc: '5',
+			});
+		});
+
+		test('correctly buckets content published 12 months ago', () => {
+			expect(
+				getContentTargeting({
+					...defaultValues,
+					webPublicationDate: new Date(
+						'January 1, 2022 00:00:00',
+					).getTime(),
+				}),
+			).toMatchObject({
+				rc: '6',
+			});
+		});
+
+		test('correctly buckets content published 14 months and 1 second ago', () => {
+			expect(
+				getContentTargeting({
+					...defaultValues,
+					webPublicationDate: new Date(
+						'October 31, 2021 23:59:59',
+					).getTime(),
+				}),
+			).toMatchObject({
+				rc: '7',
+			});
+		});
+	});
 });

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -58,6 +58,7 @@ export type GuardianWindowConfig = {
 		section: string;
 		sharedAdTargeting?: Record<string, string | string[]>;
 		videoDuration: number;
+		webPublicationDate: number;
 	};
 	tests?: {
 		[key: `${string}Control`]: 'control';


### PR DESCRIPTION
## What does this change?

Adds a new targeting key-value `rc` ("Recently Published Content"). 

As per [this document](https://docs.google.com/document/d/1toiKkrrThWHB72GYFuirE2ktGnljwcOsdZbsr0DUTUU/edit#), the bucketing should work as follows:

| `rc` | Meaning |
| --- | --- |
| 0 | Content < 2 hours old |
| 1 | Content between 2 hours and 24 hours old |
| 2 | Content between 24 hours and 3 days old |
| 3 | Content between 3 and 7 days old |
| 4 | Content between 7 days and 1 month old |
| 5 | Content more than 1 month old but less than 10 months old |
| 6 | Content more than 10 months old less than 14 months old |
| 7 | Content more than 14 months old |


## Why?

To allow line items to target content based on date of publication.