### PR TITLE
ci: use yarn to publish

### DIFF
--- a/core/.releaserc.json
+++ b/core/.releaserc.json
@@ -4,7 +4,18 @@
 	"plugins": [
 		"@semantic-release/commit-analyzer",
 		"@semantic-release/release-notes-generator",
-		"@semantic-release/npm",
+		[
+			"@semantic-release/npm",
+			{
+				"npmPublish": false
+			}
+		],
+		[
+			"@semantic-release/exec",
+			{
+				"publishCmd": "yarn npm publish"
+			}
+		],
 		"@semantic-release/github"
 	],
 	"preset": "conventionalcommits"


### PR DESCRIPTION
## What does this change?
semantic-release can only use npm to publish, which can't resolve dependencies for some reason, `yarn npm publish` should be able to do the trick https://yarnpkg.com/cli/npm/publish
