### PR TITLE
fix(bundle): include used process.env.* in prod build

### DIFF
--- a/.github/workflows/standalone-e2e.yml
+++ b/.github/workflows/standalone-e2e.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 on:
   workflow_dispatch:
-  # pull_request:
+  pull_request:
 
 concurrency:
   group: "e2e-${{ github.head_ref }}"

--- a/.github/workflows/standalone-e2e.yml
+++ b/.github/workflows/standalone-e2e.yml
@@ -53,7 +53,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           working-directory: commercial/e2e
-          start: make -C ../../dcr/dotcom-rendering start-ci, yarn --cwd ../ workspace @guardian/commercial-standalone serve
+          start: make -C ../../dcr/dotcom-rendering start-ci, yarn --cwd ../ workspace @guardian/commercial-bundle serve
           wait-on: "http://localhost:3030, http://localhost:3031/graun.standalone.commercial.js"
           wait-on-timeout: 30
           browser: chrome

--- a/bundle/webpack.config.dev.js
+++ b/bundle/webpack.config.dev.js
@@ -29,12 +29,6 @@ module.exports = webpackMerge.smart(config, {
 					process: 'process/browser',
 				}),
 		  ],
-
-	resolve: {
-		alias: {
-			process: 'process/browser',
-		},
-	},
 	devServer: {
 		port,
 		compress: true,

--- a/bundle/webpack.config.dev.js
+++ b/bundle/webpack.config.dev.js
@@ -29,6 +29,12 @@ module.exports = webpackMerge.smart(config, {
 					process: 'process/browser',
 				}),
 		  ],
+
+	resolve: {
+		alias: {
+			process: 'process/browser',
+		},
+	},
 	devServer: {
 		port,
 		compress: true,

--- a/bundle/webpack.config.js
+++ b/bundle/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
 	},
 	output: {
 		path: path.join(__dirname, 'dist'),
+		clean: true,
 	},
 	resolve: {
 		modules: [
@@ -25,7 +26,6 @@ module.exports = {
 			svgs: path.join(__dirname, 'static', 'svg'),
 			'ophan/ng': 'ophan-tracker-js',
 			lodash: 'lodash-es',
-			process: 'process/browser',
 		},
 		extensions: ['.js', '.ts', '.tsx', '.jsx'],
 		symlinks: false, // Inserted to enable linking @guardian/consent-management-platform
@@ -60,9 +60,6 @@ module.exports = {
 			exclude: /node_modules/,
 			// add errors to webpack instead of warnings
 			failOnError: true,
-		}),
-		new webpack.ProvidePlugin({
-			process: 'process/browser',
 		}),
 	],
 };

--- a/bundle/webpack.config.js
+++ b/bundle/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = {
 			svgs: path.join(__dirname, 'static', 'svg'),
 			'ophan/ng': 'ophan-tracker-js',
 			lodash: 'lodash-es',
+			process: 'process/browser',
 		},
 		extensions: ['.js', '.ts', '.tsx', '.jsx'],
 		symlinks: false, // Inserted to enable linking @guardian/consent-management-platform
@@ -59,6 +60,9 @@ module.exports = {
 			exclude: /node_modules/,
 			// add errors to webpack instead of warnings
 			failOnError: true,
+		}),
+		new webpack.ProvidePlugin({
+			process: 'process/browser',
 		}),
 	],
 };

--- a/bundle/webpack.config.prod.js
+++ b/bundle/webpack.config.prod.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const BundleAnalyzerPlugin =
 	require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
@@ -17,6 +18,10 @@ module.exports = webpackMerge.smart(config, {
 			analyzerMode: 'static',
 			openAnalyzer: false,
 		}),
+		new webpack.DefinePlugin({
+            'process.env.NODE_ENV': JSON.stringify('production'),
+			'process.env.OVERRIDE_BUNDLE_PATH': JSON.stringify('false'),
+        }),
 	],
 	optimization: {
 		minimize: true,

--- a/bundle/webpack.config.prod.js
+++ b/bundle/webpack.config.prod.js
@@ -19,9 +19,9 @@ module.exports = webpackMerge.smart(config, {
 			openAnalyzer: false,
 		}),
 		new webpack.DefinePlugin({
-            'process.env.NODE_ENV': JSON.stringify('production'),
+			'process.env.NODE_ENV': JSON.stringify('production'),
 			'process.env.OVERRIDE_BUNDLE_PATH': JSON.stringify('false'),
-        }),
+		}),
 	],
 	optimization: {
 		minimize: true,


### PR DESCRIPTION
## What does this change?
webpack was only aliasing the `process` module in the dev build, so the prod build didn't actually work in the browser.

Also re-enable the E2E tests that would have caught this...

