### PR TITLE
fix: Allow beta releases

### DIFF
--- a/.github/workflows/CI-commercial-bundle.yml
+++ b/.github/workflows/CI-commercial-bundle.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "main"
+      - "beta"
   pull_request:
     branches-ignore:
       - "gh-pages"
@@ -79,15 +80,16 @@ jobs:
         run: yarn build
 
       - name: Save build
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
         uses: actions/upload-artifact@v3
         with:
-          name: bundle
-          path: bundle/dist
+          name: core
+          path: core/dist
+
   release:
     name: Release
     needs: [build, test, lint, types]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -105,8 +107,8 @@ jobs:
       - name: Fetch build
         uses: actions/download-artifact@v3
         with:
-          name: bundle
-          path: bundle/dist
+          name: core
+          path: core/dist
 
       - name: Release
         run: yarn semantic-release

--- a/.github/workflows/CI-commercial-core.yml
+++ b/.github/workflows/CI-commercial-core.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "main"
+      - "beta"
   pull_request:
     branches-ignore:
       - "gh-pages"
@@ -99,7 +100,7 @@ jobs:
         run: yarn build
 
       - name: Save build
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3
         with:
           name: core
@@ -108,7 +109,7 @@ jobs:
   release:
     name: Release
     needs: [build, test, lint, types]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/bundle/.releaserc.json
+++ b/bundle/.releaserc.json
@@ -1,6 +1,6 @@
 {
 	"extends": "semantic-release-monorepo",
-	"branches": "main",
+	"branches": ["main", "beta"],
 	"plugins": [
 		"@semantic-release/commit-analyzer",
 		"@semantic-release/release-notes-generator",

--- a/core/.releaserc.json
+++ b/core/.releaserc.json
@@ -1,6 +1,6 @@
 {
 	"extends": "semantic-release-monorepo",
-	"branches": "main",
+	"branches": ["main", "beta"],
 	"plugins": [
 		"@semantic-release/commit-analyzer",
 		"@semantic-release/release-notes-generator",


### PR DESCRIPTION
## What does this change?
Enable pre-releasing of `beta/*` branches

A label would be more useful, but would be more difficult due to the way actions and sematic-release work

## Why?
So that we can more easily test changes against frontend CODE for example
