### PR TITLE
fix(e2e): correct DCR dev server path

### DIFF
--- a/core/src/event-timer.ts
+++ b/core/src/event-timer.ts
@@ -38,7 +38,6 @@ interface EventTimerProperties {
 	type?: ConnectionType;
 	downlink?: number;
 	effectiveType?: string;
-	offlineCount?: number;
 	adSlotsInline?: number;
 	adSlotsTotal?: number;
 	// the height of the page / the viewport height
@@ -158,9 +157,7 @@ class EventTimer {
 			],
 		};
 
-		this.properties = {
-			offlineCount: window.guardian.offlineCount,
-		};
+		this.properties = {};
 
 		if (window.navigator.connection) {
 			this.properties.type = window.navigator.connection.type;

--- a/core/src/send-commercial-metrics.spec.ts
+++ b/core/src/send-commercial-metrics.spec.ts
@@ -505,6 +505,62 @@ describe('send commercial metrics', () => {
 			]);
 		});
 	});
+
+	describe('record offline count', () => {
+		it('returns the value if present', async () => {
+			mockOnConsent(tcfv2AllConsent);
+
+			await initCommercialMetrics({
+				pageViewId: PAGE_VIEW_ID,
+				browserId: BROWSER_ID,
+				isDev: IS_NOT_DEV,
+				adBlockerInUse: ADBLOCK_NOT_IN_USE,
+				sampling: USER_IN_SAMPLING,
+			});
+
+			window.guardian.offlineCount = 3;
+
+			setVisibility('hidden');
+			global.dispatchEvent(new Event('pagehide'));
+
+			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+				[
+					Endpoints.PROD,
+					JSON.stringify({
+						...defaultMetrics,
+						metrics: [{ name: 'offlineCount', value: 3 }],
+					}),
+				],
+			]);
+		});
+
+		it('returns nothing if absent', async () => {
+			mockOnConsent(tcfv2AllConsent);
+
+			await initCommercialMetrics({
+				pageViewId: PAGE_VIEW_ID,
+				browserId: BROWSER_ID,
+				isDev: IS_NOT_DEV,
+				adBlockerInUse: ADBLOCK_NOT_IN_USE,
+				sampling: USER_IN_SAMPLING,
+			});
+
+			delete window.guardian.offlineCount;
+
+			setVisibility('hidden');
+			global.dispatchEvent(new Event('pagehide'));
+
+			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+				[
+					Endpoints.PROD,
+					JSON.stringify({
+						...defaultMetrics,
+						metrics: [],
+					}),
+				],
+			]);
+		});
+	});
 });
 
 describe('send commercial metrics helpers', () => {

--- a/core/src/send-commercial-metrics.ts
+++ b/core/src/send-commercial-metrics.ts
@@ -23,7 +23,6 @@ type EventProperties = {
 	type?: ConnectionType;
 	downlink?: number;
 	effectiveType?: string;
-	offlineCount?: number;
 };
 
 type CommercialMetricsPayload = {
@@ -110,6 +109,25 @@ function sendMetrics() {
 
 type ArrayMetric = [key: string, value: string | number];
 
+/**
+ * Gather how many times the user has experienced the “offline” event
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/offline_event
+ *
+ * This value should be fetched as late as possible in the page lifecycle,
+ * to get an accurate value.
+ *
+ * Relevant for an @guardian/open-journalism investigation.
+ */
+const getOfflineCount = (): Metric[] =>
+	window.guardian.offlineCount
+		? [
+				{
+					name: 'offlineCount',
+					value: window.guardian.offlineCount,
+				},
+		  ]
+		: [];
+
 function gatherMetricsOnPageUnload(): void {
 	// Assemble commercial properties and metrics
 	const eventTimer = EventTimer.get();
@@ -126,7 +144,9 @@ function gatherMetricsOnPageUnload(): void {
 		.concat(adBlockerProperties);
 	commercialMetricsPayload.properties = properties;
 
-	const metrics: readonly Metric[] = roundTimeStamp(eventTimer.events);
+	const metrics: readonly Metric[] = roundTimeStamp(eventTimer.events).concat(
+		getOfflineCount(),
+	);
 	commercialMetricsPayload.metrics = metrics;
 
 	sendMetrics();

--- a/e2e/cypress/lib/util.ts
+++ b/e2e/cypress/lib/util.ts
@@ -27,7 +27,7 @@ export const getTestUrl = (
 		default: {
 			// The local bundle can be served from DCR by using COMMERCIAL_BUNDLE_URL when starting DCR to test changes locally without needing to launch frontend
 			if (isDcr) {
-				url = `http://localhost:3030/Article?url=https://theguardian.com${path}`;
+				url = `http://localhost:3030/Article/https://theguardian.com${path}`;
 			} else {
 				url = `http://localhost:9000${path}`;
 			}


### PR DESCRIPTION
## What does this change?

Use the correct DCR dev server endpoint.

## Why?

It has changed in https://github.com/guardian/dotcom-rendering/pull/7166